### PR TITLE
Feat: Implements the `get_ancestors()`, `get_descendants()` methods. (#2383)

### DIFF
--- a/pgmpy/base/base.py
+++ b/pgmpy/base/base.py
@@ -774,7 +774,20 @@ class _CoreGraph(nx.MultiDiGraph, _GraphRolesMixin):
         >>> G = _CoreGraph()
         [Explain]
         """
-        self._validating_nodes_value(node=node, type=type)
+        reachable = set()
+        visited = set()
+        queue = deque(node)
+        nodes = self.nodes()
+
+        while queue:
+            current = queue.popleft()
+            if current not in nodes:
+                raise ValueError(f"Node {current} not in graph.")
+            if current not in visited:
+                visited.add(current)
+                reachable.add(current)
+                queue.extend(self.get_neighbors(current, type=type))
+        return reachable
 
     # ----------------------------------------------------------------------
     # Internal Methods (or Private Methods)

--- a/pgmpy/base/base.py
+++ b/pgmpy/base/base.py
@@ -669,17 +669,15 @@ class _CoreGraph(nx.MultiDiGraph, _GraphRolesMixin):
         >>> G = _CoreGraph()
         [Explain]
         """
+        if node not in self.nodes():
+            raise ValueError(f"Node {node} not in graph.")
+
         ancestors = set()
-        visited = set()
-        queue = deque(node)
-        nodes = self.nodes()
+        queue = deque([node])
 
         while queue:
             current = queue.popleft()
-            if current not in nodes:
-                raise ValueError(f"Node {current} not in graph.")
-            elif current not in visited:
-                visited.add(current)
+            if current not in ancestors:
                 ancestors.add(current)
                 queue.extend(self.get_parents(current))
         return ancestors
@@ -719,17 +717,15 @@ class _CoreGraph(nx.MultiDiGraph, _GraphRolesMixin):
         >>> G = _CoreGraph()
         [Explain]
         """
+        if node not in self.nodes():
+            raise ValueError(f"Node {node} not in graph.")
+
         descendants = set()
-        visited = set()
-        queue = deque(node)
-        nodes = self.nodes()
+        queue = deque([node])
 
         while queue:
             current = queue.popleft()
-            if current not in nodes:
-                raise ValueError(f"Node {current} not in graph.")
-            if current not in visited:
-                visited.add(current)
+            if current not in descendants:
                 descendants.add(current)
                 queue.extend(self.get_children(current))
         return descendants
@@ -771,17 +767,15 @@ class _CoreGraph(nx.MultiDiGraph, _GraphRolesMixin):
         >>> G = _CoreGraph()
         [Explain]
         """
+        if node not in self.nodes():
+            raise ValueError(f"Node {node} not in graph.")
+
         reachable = set()
-        visited = set()
-        queue = deque(node)
-        nodes = self.nodes()
+        queue = deque([node])
 
         while queue:
             current = queue.popleft()
-            if current not in nodes:
-                raise ValueError(f"Node {current} not in graph.")
-            if current not in visited:
-                visited.add(current)
+            if current not in reachable:
                 reachable.add(current)
                 queue.extend(self.get_neighbors(current, type=type))
         return reachable

--- a/pgmpy/base/base.py
+++ b/pgmpy/base/base.py
@@ -215,8 +215,7 @@ class _CoreGraph(nx.MultiDiGraph, _GraphRolesMixin):
             super().add_edge(v, u, key=type, **kwargs)
         else:
             raise AssertionError(
-                "This should never happen."
-                "If you see this error, please file an issue on the pgmpy GitHub."
+                "This is an unexpected error in pgmpy. If you see this error, please file an issue on the pgmpy GitHub."
             )
 
     def add_edges_from(
@@ -323,8 +322,7 @@ class _CoreGraph(nx.MultiDiGraph, _GraphRolesMixin):
             super().remove_edge(v, u, key=type)
         else:
             raise AssertionError(
-                "This should never happen."
-                "If you see this error, please file an issue on the pgmpy GitHub."
+                "This is an unexpected error in pgmpy. If you see this error, please file an issue on the pgmpy GitHub."
             )
 
     def remove_edges_from(
@@ -519,8 +517,7 @@ class _CoreGraph(nx.MultiDiGraph, _GraphRolesMixin):
                     result.add(neighbor)
         else:
             raise AssertionError(
-                "This should never happen."
-                "If you see this error, please file an issue on the pgmpy GitHub."
+                "This is an unexpected error in pgmpy. If you see this error, please file an issue on the pgmpy GitHub."
             )
         return result
 

--- a/pgmpy/base/base.py
+++ b/pgmpy/base/base.py
@@ -201,18 +201,19 @@ class _CoreGraph(nx.MultiDiGraph, _GraphRolesMixin):
         self._validating_edges_value(ebunch=[(u, v, type)])
 
         # Adding edge base on type value.
-        if type in ["->", "<-", "o>", "<o"]:
-            if type in ["<-", "<o"]:
-                u, v = v, u
-                type = f"{type[1]}>"
-            super().add_edge(u, v, key=type, **kwargs)
-        elif type in ["--", "-o", "o-"]:
+        if type in ["<-", "<o"]:
+            u, v = v, u
+            type = f"{type[1]}>"
+        super().add_edge(u, v, key=type, **kwargs)
+
+        # Further adding edge based on the edge's type.
+        if type in ["--", "-o", "o-"]:
             reverse_type = f"{type[1]}{type[0]}"
-            super().add_edge(u, v, key=type, **kwargs)
             super().add_edge(v, u, key=reverse_type, **kwargs)
         elif type in ["<>", "oo"]:
-            super().add_edge(u, v, key=type, **kwargs)
             super().add_edge(v, u, key=type, **kwargs)
+        elif type in ["->", "<-", "o>", "<o"]:
+            pass
         else:
             raise AssertionError(
                 "This is an unexpected error in pgmpy. If you see this error, please file an issue on the pgmpy GitHub."
@@ -308,18 +309,19 @@ class _CoreGraph(nx.MultiDiGraph, _GraphRolesMixin):
         self._validating_edges_value(ebunch=[(u, v, type)])
 
         # Removing edge base on `type` value.
-        if type in ["->", "<-", "o>", "<o"]:
-            if type in ["<-", "<o"]:
-                u, v = v, u
-                type = f"{type[1]}>"
-            super().remove_edge(u, v, key=type)
-        elif type in ["--", "-o", "o-"]:
+        if type in ["<-", "<o"]:
+            u, v = v, u
+            type = f"{type[1]}>"
+        super().remove_edge(u, v, key=type)
+
+        # Further removing edge based on the edge's type.
+        if type in ["--", "-o", "o-"]:
             reverse_type = f"{type[1]}{type[0]}"
-            super().remove_edge(u, v, key=type)
             super().remove_edge(v, u, key=reverse_type)
         elif type in ["<>", "oo"]:
-            super().remove_edge(u, v, key=type)
             super().remove_edge(v, u, key=type)
+        elif type in ["->", "<-", "o>", "<o"]:
+            pass
         else:
             raise AssertionError(
                 "This is an unexpected error in pgmpy. If you see this error, please file an issue on the pgmpy GitHub."

--- a/pgmpy/base/base.py
+++ b/pgmpy/base/base.py
@@ -1,3 +1,4 @@
+from collections import deque
 from typing import Hashable, Iterable, Optional
 
 import networkx as nx
@@ -671,7 +672,20 @@ class _CoreGraph(nx.MultiDiGraph, _GraphRolesMixin):
         >>> G = _CoreGraph()
         [Explain]
         """
-        self._validating_nodes_value(node=node)
+        ancestors = set()
+        visited = set()
+        queue = deque(node)
+        nodes = self.nodes()
+
+        while queue:
+            current = queue.popleft()
+            if current not in nodes:
+                raise ValueError(f"Node {current} not in graph.")
+            elif current not in visited:
+                visited.add(current)
+                ancestors.add(current)
+                queue.extend(self.get_parents(current))
+        return ancestors
 
     def get_descendants(self, node):
         """
@@ -708,7 +722,20 @@ class _CoreGraph(nx.MultiDiGraph, _GraphRolesMixin):
         >>> G = _CoreGraph()
         [Explain]
         """
-        self._validating_nodes_value(node=node)
+        descendants = set()
+        visited = set()
+        queue = deque(node)
+        nodes = self.nodes()
+
+        while queue:
+            current = queue.popleft()
+            if current not in nodes:
+                raise ValueError(f"Node {current} not in graph.")
+            if current not in visited:
+                visited.add(current)
+                descendants.add(current)
+                queue.extend(self.get_children(current))
+        return descendants
 
     def get_reachable_nodes(self, node, type):
         """

--- a/pgmpy/tests/test_base/test_base.py
+++ b/pgmpy/tests/test_base/test_base.py
@@ -1760,19 +1760,19 @@ class TestCoreGraph:
         check_graph_status(graph, 5, 4, set(), set(), set(), {})
 
         graph = sample_graph2(type="o>")
-        assert graph.get_reachable_nodes("B", "o>") == {"A", "B", "C", "D", "E"}
+        assert graph.get_reachable_nodes("B", "o>") == {"B", "C", "D"}
         check_graph_status(graph, 4, 3, set(), set(), set(), {})
 
         graph = sample_graph2(type="<o")
-        assert graph.get_reachable_nodes("B", "<o") == {"A", "B", "C", "D"}
+        assert graph.get_reachable_nodes("B", "<o") == {"B", "C", "D"}
         check_graph_status(graph, 4, 3, set(), set(), set(), {})
 
         graph = sample_graph2(type="-o")
-        assert graph.get_reachable_nodes("B", "-o") == {"A", "B", "C", "D"}
+        assert graph.get_reachable_nodes("B", "-o") == {"B", "C", "D"}
         check_graph_status(graph, 4, 3, set(), set(), set(), {})
 
         graph = sample_graph2(type="o-")
-        assert graph.get_reachable_nodes("B", "o-") == {"A", "B", "C", "D"}
+        assert graph.get_reachable_nodes("B", "o-") == {"B", "C", "D"}
         check_graph_status(graph, 4, 3, set(), set(), set(), {})
 
         graph = sample_graph2(type="oo")
@@ -1786,8 +1786,6 @@ class TestCoreGraph:
             "A",
             "B",
             "X",
-            "E",
-            "I",
         }
         assert graph.get_reachable_nodes("A", "<-") == {
             "A",
@@ -1815,7 +1813,7 @@ class TestCoreGraph:
         graph.add_node("A")
         graph.add_node("B")
 
-        assert graph.get_reachable_nodes("A") == set()
+        assert graph.get_reachable_nodes("A", "->") == {"A"}
         check_graph_status(graph, 2, 0, set(), set(), set(), {})
 
         # Test3: Wrong input values.
@@ -1823,7 +1821,7 @@ class TestCoreGraph:
 
         with pytest.raises(TypeError):
             graph.get_reachable_nodes()
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError):
             graph.get_reachable_nodes("A")
 
         check_graph_status(graph, 0, 0, set(), set(), set(), {})

--- a/pgmpy/tests/test_base/test_base.py
+++ b/pgmpy/tests/test_base/test_base.py
@@ -1483,64 +1483,64 @@ class TestCoreGraph:
         """Test `get_ancestors` method of the `_CoreGraph` class with undirect edges."""
         # Test1: edge.
         graph = sample_graph1(type="--")
-        assert graph.get_ancestors("C") == set()
+        assert graph.get_ancestors("C") == {"C"}
         check_graph_status(graph, 5, 4, set(), set(), set(), {})
 
         graph = sample_graph2(type="--")
-        assert graph.get_ancestors("B") == set()
+        assert graph.get_ancestors("B") == {"B"}
         check_graph_status(graph, 4, 3, set(), set(), set(), {})
 
     def test_get_ancestors_with_bidirect_edges(self):
         """Test `get_ancestors` method of the `_CoreGraph` class with bidirect edges."""
         # Test1: edge.
         graph = sample_graph1(type="<>")
-        assert graph.get_ancestors("C") == set()
+        assert graph.get_ancestors("C") == {"C"}
         check_graph_status(graph, 5, 4, set(), set(), set(), {})
 
         graph = sample_graph2(type="<>")
-        assert graph.get_ancestors("B") == set()
+        assert graph.get_ancestors("B") == {"B"}
         check_graph_status(graph, 4, 3, set(), set(), set(), {})
 
     def test_get_ancestors_with_unknown_edges(self):
         """Test `get_ancestors` method of the `_CoreGraph` class with unknown edges."""
         graph = sample_graph1(type="o>")
-        assert graph.get_ancestors("C") == set()
+        assert graph.get_ancestors("C") == {"C"}
         check_graph_status(graph, 5, 4, set(), set(), set(), {})
 
         graph = sample_graph1(type="<o")
-        assert graph.get_ancestors("C") == set()
+        assert graph.get_ancestors("C") == {"C"}
         check_graph_status(graph, 5, 4, set(), set(), set(), {})
 
         graph = sample_graph1(type="-o")
-        assert graph.get_ancestors("C") == set()
+        assert graph.get_ancestors("C") == {"C"}
         check_graph_status(graph, 5, 4, set(), set(), set(), {})
 
         graph = sample_graph1(type="o-")
-        assert graph.get_ancestors("C") == set()
+        assert graph.get_ancestors("C") == {"C"}
         check_graph_status(graph, 5, 4, set(), set(), set(), {})
 
         graph = sample_graph1(type="oo")
-        assert graph.get_ancestors("C") == set()
+        assert graph.get_ancestors("C") == {"C"}
         check_graph_status(graph, 5, 4, set(), set(), set(), {})
 
         graph = sample_graph2(type="o>")
-        assert graph.get_ancestors("B") == set()
+        assert graph.get_ancestors("B") == {"B"}
         check_graph_status(graph, 4, 3, set(), set(), set(), {})
 
         graph = sample_graph2(type="<o")
-        assert graph.get_ancestors("B") == set()
+        assert graph.get_ancestors("B") == {"B"}
         check_graph_status(graph, 4, 3, set(), set(), set(), {})
 
         graph = sample_graph2(type="-o")
-        assert graph.get_ancestors("B") == set()
+        assert graph.get_ancestors("B") == {"B"}
         check_graph_status(graph, 4, 3, set(), set(), set(), {})
 
         graph = sample_graph2(type="o-")
-        assert graph.get_ancestors("B") == set()
+        assert graph.get_ancestors("B") == {"B"}
         check_graph_status(graph, 4, 3, set(), set(), set(), {})
 
         graph = sample_graph2(type="oo")
-        assert graph.get_ancestors("B") == set()
+        assert graph.get_ancestors("B") == {"B"}
         check_graph_status(graph, 4, 3, set(), set(), set(), {})
 
     def test_get_ancestors_with_multiedges(self):
@@ -1564,7 +1564,7 @@ class TestCoreGraph:
         graph.add_node("A")
         graph.add_node("B")
 
-        assert graph.get_ancestors("A") == set()
+        assert graph.get_ancestors("A") == {"A"}
         check_graph_status(graph, 2, 0, set(), set(), set(), {})
 
         # Test3: Wrong input values.
@@ -1573,7 +1573,7 @@ class TestCoreGraph:
         with pytest.raises(TypeError):
             graph.get_ancestors()
         with pytest.raises(ValueError):
-            graph.get_ancestors(1)
+            graph.get_ancestors("1")
         check_graph_status(graph, 0, 0, set(), set(), set(), {})
 
     # get_descendants
@@ -1601,64 +1601,64 @@ class TestCoreGraph:
         """Test `get_descendants` method of the `_CoreGraph` class with undirect edges."""
         # Test1: edge.
         graph = sample_graph1(type="--")
-        assert graph.get_descendants("C") == set()
+        assert graph.get_descendants("C") == {"C"}
         check_graph_status(graph, 5, 4, set(), set(), set(), {})
 
         graph = sample_graph2(type="--")
-        assert graph.get_descendants("B") == set()
+        assert graph.get_descendants("B") == {"B"}
         check_graph_status(graph, 4, 3, set(), set(), set(), {})
 
     def test_get_descendants_with_bidirect_edges(self):
         """Test `get_descendants` method of the `_CoreGraph` class with bidirect edges."""
         # Test1: edge.
         graph = sample_graph1(type="<>")
-        assert graph.get_descendants("C") == set()
+        assert graph.get_descendants("C") == {"C"}
         check_graph_status(graph, 5, 4, set(), set(), set(), {})
 
         graph = sample_graph2(type="<>")
-        assert graph.get_descendants("B") == set()
+        assert graph.get_descendants("B") == {"B"}
         check_graph_status(graph, 4, 3, set(), set(), set(), {})
 
     def test_get_descendants_with_unknown_edges(self):
         """Test `get_descendants` method of the `_CoreGraph` class with unknown edges."""
         graph = sample_graph1(type="o>")
-        assert graph.get_descendants("C") == set()
+        assert graph.get_descendants("C") == {"C"}
         check_graph_status(graph, 5, 4, set(), set(), set(), {})
 
         graph = sample_graph1(type="<o")
-        assert graph.get_descendants("C") == set()
+        assert graph.get_descendants("C") == {"C"}
         check_graph_status(graph, 5, 4, set(), set(), set(), {})
 
         graph = sample_graph1(type="-o")
-        assert graph.get_descendants("C") == set()
+        assert graph.get_descendants("C") == {"C"}
         check_graph_status(graph, 5, 4, set(), set(), set(), {})
 
         graph = sample_graph1(type="o-")
-        assert graph.get_descendants("C") == set()
+        assert graph.get_descendants("C") == {"C"}
         check_graph_status(graph, 5, 4, set(), set(), set(), {})
 
         graph = sample_graph1(type="oo")
-        assert graph.get_descendants("C") == set()
+        assert graph.get_descendants("C") == {"C"}
         check_graph_status(graph, 5, 4, set(), set(), set(), {})
 
         graph = sample_graph2(type="o>")
-        assert graph.get_descendants("B") == set()
+        assert graph.get_descendants("B") == {"B"}
         check_graph_status(graph, 4, 3, set(), set(), set(), {})
 
         graph = sample_graph2(type="<o")
-        assert graph.get_descendants("B") == set()
+        assert graph.get_descendants("B") == {"B"}
         check_graph_status(graph, 4, 3, set(), set(), set(), {})
 
         graph = sample_graph2(type="-o")
-        assert graph.get_descendants("B") == set()
+        assert graph.get_descendants("B") == {"B"}
         check_graph_status(graph, 4, 3, set(), set(), set(), {})
 
         graph = sample_graph2(type="o-")
-        assert graph.get_descendants("B") == set()
+        assert graph.get_descendants("B") == {"B"}
         check_graph_status(graph, 4, 3, set(), set(), set(), {})
 
         graph = sample_graph2(type="oo")
-        assert graph.get_descendants("B") == set()
+        assert graph.get_descendants("B") == {"B"}
         check_graph_status(graph, 4, 3, set(), set(), set(), {})
 
     def test_get_descendants_with_multiedges(self):
@@ -1682,7 +1682,7 @@ class TestCoreGraph:
         graph.add_node("A")
         graph.add_node("B")
 
-        assert graph.get_descendants("A") == set()
+        assert graph.get_descendants("A") == {"A"}
         check_graph_status(graph, 2, 0, set(), set(), set(), {})
 
         # Test3: Wrong input values.
@@ -1691,7 +1691,7 @@ class TestCoreGraph:
         with pytest.raises(TypeError):
             graph.get_descendants()
         with pytest.raises(ValueError):
-            graph.get_descendants(1)
+            graph.get_descendants("1")
         check_graph_status(graph, 0, 0, set(), set(), set(), {})
 
     # get_reachable_nodes
@@ -1699,20 +1699,20 @@ class TestCoreGraph:
         """Test `get_reachable_nodes` method of the `_CoreGraph` class with direct edges."""
         # Test1: edge.
         graph = sample_graph1(type="->")
-        assert graph.get_reachable_nodes("C", "->") == {"A", "B", "C", "D", "E"}
+        assert graph.get_reachable_nodes("C", "->") == {"C", "D", "E"}
         check_graph_status(graph, 5, 4, set(), set(), set(), {})
 
         graph = sample_graph2(type="->")
-        assert graph.get_reachable_nodes("B", "->") == {"A", "B", "C", "D"}
+        assert graph.get_reachable_nodes("B", "->") == {"B", "C", "D"}
         check_graph_status(graph, 4, 3, set(), set(), set(), {})
 
         # Test2: reverse edge.
         graph = sample_graph1(type="<-")
-        assert graph.get_reachable_nodes("C", "<-") == {"A", "B", "C", "D", "E"}
+        assert graph.get_reachable_nodes("C", "<-") == {"C", "D", "E"}
         check_graph_status(graph, 5, 4, set(), set(), set(), {})
 
         graph = sample_graph2(type="<-")
-        assert graph.get_reachable_nodes("B", "<-") == {"A", "B", "C", "D"}
+        assert graph.get_reachable_nodes("B", "<-") == {"B", "C", "D"}
         check_graph_status(graph, 4, 3, set(), set(), set(), {})
 
     def test_get_reachable_nodes_with_undirect_edges(self):
@@ -1740,19 +1740,19 @@ class TestCoreGraph:
     def test_get_reachable_nodes_with_unknown_edges(self):
         """Test `get_reachable_nodes` method of the `_CoreGraph` class with unknown edges."""
         graph = sample_graph1(type="o>")
-        assert graph.get_reachable_nodes("C", "o>") == {"A", "B", "C", "D", "E"}
+        assert graph.get_reachable_nodes("C", "o>") == {"C", "D", "E"}
         check_graph_status(graph, 5, 4, set(), set(), set(), {})
 
         graph = sample_graph1(type="<o")
-        assert graph.get_reachable_nodes("C", "<o") == {"A", "B", "C", "D", "E"}
+        assert graph.get_reachable_nodes("C", "<o") == {"C", "D", "E"}
         check_graph_status(graph, 5, 4, set(), set(), set(), {})
 
         graph = sample_graph1(type="-o")
-        assert graph.get_reachable_nodes("C", "-o") == {"A", "B", "C", "D", "E"}
+        assert graph.get_reachable_nodes("C", "-o") == {"C", "D", "E"}
         check_graph_status(graph, 5, 4, set(), set(), set(), {})
 
         graph = sample_graph1(type="o-")
-        assert graph.get_reachable_nodes("C", "o-") == {"A", "B", "C", "D", "E"}
+        assert graph.get_reachable_nodes("C", "o-") == {"C", "D", "E"}
         check_graph_status(graph, 5, 4, set(), set(), set(), {})
 
         graph = sample_graph1(type="oo")


### PR DESCRIPTION
Fix: Fix test case (#2383)
- `get_ancestors()`, `get_descendants()`, `get_reachable_nodes()` should include node-self.

Feat: Implements the `get_ancestors()`, `get_descendants()` methods. (#2383)
