### PR TITLE
Review

### DIFF
--- a/pgmpy/base/_base.py
+++ b/pgmpy/base/_base.py
@@ -109,7 +109,7 @@ class _CoreGraph(nx.MultiGraph, _GraphAlgorithmMixin, _GraphRolesMixin):
     >>> G.latents
     {'D'}
 
-    In addition to 'exposure', 'outcomes', and 'latents', you can add  custom roles.
+    In addition to 'exposure', 'outcomes', and 'latents', you can add custom roles.
 
     >>> edges = [("A", "B", "->"), ("B", "C", "->"), ("D", "C", "-o")]
     >>> G = _CoreGraph(ebunch=edges)
@@ -213,14 +213,10 @@ class _CoreGraph(nx.MultiGraph, _GraphAlgorithmMixin, _GraphRolesMixin):
         [('A', 'B', 0, '->')]
 
         """
-        if isinstance(edge_type, str):
-            self._validate_edges(ebunch=[(u, v, edge_type)])
-            self._validate_graph_specific_edges(ebunch=[(u, v, edge_type)])
-            _markers_dict = self._from_api_edge_type(edge=[u, v, edge_type])
-        elif isinstance(edge_type, dict):
-            _markers_dict = edge_type
-        else:
-            raise ValueError("edge_type must be a string.")
+        self._validate_edges(ebunch=[(u, v, edge_type)])
+        self._validate_graph_specific_edges(ebunch=[(u, v, edge_type)])
+
+        _markers_dict = self._from_api_edge_type(edge=[u, v, edge_type])
 
         _key = super().add_edge(u, v, key=key, **kwargs)
         self.edges[u, v, _key].update({u: _markers_dict[u], v: _markers_dict[v]})
@@ -406,11 +402,12 @@ class _CoreGraph(nx.MultiGraph, _GraphAlgorithmMixin, _GraphRolesMixin):
         <class 'pgmpy.base._base._CoreGraph'>
 
         """
-        ebunch = [(u, v, key, edge_type) for u, v, key, edge_type in self.edges(keys=True, data=True)]
+        ebunch = [(u, v, key, markers) for u, v, key, markers in self.edges(keys=True, data=True)]
 
         graph_copy = self.__class__()
         graph_copy.add_nodes_from(self.nodes(data=True))
-        for u, v, key, edge_type in ebunch:
+        for u, v, key, markers in ebunch:
+            edge_type = self._to_api_edge_type(u, v, markers=markers)
             graph_copy.add_edge(u, v, edge_type=edge_type, key=key)
         for role, vars in self.get_role_dict().items():
             graph_copy.with_role(role=role, variables=vars, inplace=True)
@@ -814,7 +811,7 @@ class _CoreGraph(nx.MultiGraph, _GraphAlgorithmMixin, _GraphRolesMixin):
         # (u, v, edge_type) or (u, v, key, edge_type)
         return [(*edge[:-1], self._to_api_edge_type(edge[0], edge[1], edge[-1])) for edge in networkx_ebunch]
 
-    def get_edge_type(self) -> set:
+    def get_supported_edge_types(self) -> set:
         """
         Retrieves the list of supported edge types for the instance.
 
@@ -824,6 +821,44 @@ class _CoreGraph(nx.MultiGraph, _GraphAlgorithmMixin, _GraphRolesMixin):
 
         """
         return self.SUPPORTED_EDGE_TYPES
+
+    def get_edge_type(self, u: Hashable, v: Hashable, key: Any = None) -> str:
+        """
+        Retrieves the edge type for the edge between two nodes.
+
+        Parameters
+        ----------
+        u : Hashable
+            The source node of the edge.
+        v : Hashable
+            The target node of the edge.
+        key : Any, optional
+            The key identifying a specific edge between ``u`` and ``v`` in a
+            multigraph. Default is ``None``.
+
+        Returns
+        -------
+        edge_type : str
+            The edge type corresponding to the edge between ``u`` and ``v``.
+
+        Examples
+        --------
+        >>> from pgmpy.base._base import _CoreGraph
+        >>> graph = _CoreGraph()
+        >>> graph.add_edge("A", "B", "->")
+        >>> graph.add_edge("A", "B", "--")
+        >>> graph.add_edge("A", "B", "<>")
+        >>> graph.get_edge_type("A", "B", 0)
+        '->'
+        >>> graph.get_edge_type("A", "B", 1)
+        '--'
+        >>> graph.get_edge_type("A", "B", 2)
+        '<>'
+
+        """
+        markers = self[u][v][key]
+        edge_type = self._to_api_edge_type(u, v, markers)
+        return edge_type
 
     # ----------------------------------------------------------------------
     # Internal Methods (or Private Methods)
@@ -863,9 +898,7 @@ class _CoreGraph(nx.MultiGraph, _GraphAlgorithmMixin, _GraphRolesMixin):
 
     def _validate_edges(
         self,
-        ebunch: (
-            Iterable[tuple[Hashable, Hashable, Hashable]] | Iterable[tuple[Hashable, Hashable, Hashable, Hashable]]
-        ),
+        ebunch,
     ):
         """
         Validates the value input by the user, then either raises an error.
@@ -899,15 +932,14 @@ class _CoreGraph(nx.MultiGraph, _GraphAlgorithmMixin, _GraphRolesMixin):
                 raise ValueError("Nodes cannot be None.")
             if u == v:
                 raise ValueError("Nodes cannot be the same for an edge.")
-
+            if not isinstance(edge_type, str):
+                raise ValueError("edge_type must be a string.")
             if edge_type is None or edge_type not in supported_types:
                 raise ValueError(f"Types must be one of {supported_types}.")
 
     def _validate_graph_specific_edges(
         self,
-        ebunch: (
-            Iterable[tuple[Hashable, Hashable, Hashable]] | Iterable[tuple[Hashable, Hashable, Hashable, Hashable]]
-        ),
+        ebunch,
     ):
         """
         Validates graph-specific constraints on the given edges.

--- a/pgmpy/base/_mixin_algorithms.py
+++ b/pgmpy/base/_mixin_algorithms.py
@@ -57,8 +57,12 @@ class _GraphAlgorithmMixin:
         if not {u, v, w}.issubset(self.nodes):
             raise ValueError(f"{u}, {v}, {w} must be present in the graph.")
 
-        parents = self.get_parents(w)
-        spouses = self.get_spouses(w)
+        neighbors = self.neighbors(u)
+        if v in neighbors:
+            return False
+
+        parents = self.get_neighbors(w, edge_type="<-")
+        spouses = self.get_neighbors(w, edge_type="<>")
 
         incoming_to_w = parents.union(spouses)
 
@@ -379,6 +383,7 @@ class _GraphAlgorithmMixin:
         -------
         ancestral_graph: Self
             ancestral graph object
+
         Examples
         --------
         >>> from pgmpy.base._base import _CoreGraph
@@ -581,7 +586,8 @@ class _GraphAlgorithmMixin:
             is_directed_path = True
             for edge in path:
                 src, dst, key = edge
-                if self[src][dst][key] != {src: "-", dst: ">"}:
+                edge_type = self.get_edge_type(src, dst, key)
+                if edge_type != "->":
                     is_directed_path = False
                     break
             if is_directed_path:

--- a/pgmpy/tests/test_base/test_base.py
+++ b/pgmpy/tests/test_base/test_base.py
@@ -344,6 +344,9 @@ class TestCoreGraph:
         with pytest.raises(ValueError):
             graph.add_edge("A", "B", set())
 
+        with pytest.raises(ValueError):
+            graph.add_edge("A", "B", dict())
+
         assert not graph.has_edge("A", "B")
 
         assert sorted(graph.edges(keys=True, data=True)) == []
@@ -1970,6 +1973,25 @@ class TestCoreGraph:
             ]
         )
 
+    def test_get_supported_edge_types(self):
+        graph = _CoreGraph()
+        assert {"--", "-o", "o-", "->", "<-", "o>", "<o", "<>", "oo"} == graph.get_supported_edge_types()
+
     def test_get_edge_type(self):
         graph = _CoreGraph()
-        assert {"--", "-o", "o-", "->", "<-", "o>", "<o", "<>", "oo"} == graph.get_edge_type()
+
+        graph.add_edge("A", "B", "->")
+        graph.add_edge("A", "B", "--")
+        graph.add_edge("A", "B", "<>")
+        graph.add_edge("A", "B", "-o")
+        graph.add_edge("A", "B", "<-")
+        graph.add_edge("A", "B", "oo")
+        graph.add_edge("A", "B", "o-")
+
+        assert graph.get_edge_type("A", "B", 0) == "->"
+        assert graph.get_edge_type("A", "B", 1) == "--"
+        assert graph.get_edge_type("A", "B", 2) == "<>"
+        assert graph.get_edge_type("A", "B", 3) == "-o"
+        assert graph.get_edge_type("A", "B", 4) == "<-"
+        assert graph.get_edge_type("A", "B", 5) == "oo"
+        assert graph.get_edge_type("A", "B", 6) == "o-"

--- a/pgmpy/tests/test_base/test_mixin_algorithms.py
+++ b/pgmpy/tests/test_base/test_mixin_algorithms.py
@@ -109,6 +109,39 @@ class TestGraphAlgorithmMixin:
         with pytest.raises(ValueError):
             graph.is_collider("T", "O", "M")
 
+    def test_is_collider_neighbors(self):
+        graph = _CoreGraph()
+        graph.add_edge("T", "M", "->")
+
+        graph.add_edge("M", "O", "->")
+        graph.add_edge("M", "I", "<-")
+        graph.add_edge("M", "B", "<>")
+        graph.add_edge("M", "U", "--")
+
+        graph.add_edge("T", "I", "->")
+        graph.add_edge("T", "B", "<>")
+
+        assert graph.is_collider("T", "O", "M") == False
+        assert graph.is_collider("T", "I", "M") == False
+        assert graph.is_collider("T", "B", "M") == False
+        assert graph.is_collider("T", "U", "M") == False
+
+        graph = _CoreGraph()
+        graph.add_edge("T", "M", "<>")
+
+        graph.add_edge("M", "O", "->")
+        graph.add_edge("M", "I", "<-")
+        graph.add_edge("M", "B", "<>")
+        graph.add_edge("M", "U", "--")
+
+        graph.add_edge("T", "I", "--")
+        graph.add_edge("T", "B", "<-")
+
+        assert graph.is_collider("T", "O", "M") == False
+        assert graph.is_collider("T", "I", "M") == False
+        assert graph.is_collider("T", "B", "M") == False
+        assert graph.is_collider("T", "U", "M") == False
+
     @pytest.mark.skip(reason="Refactoring: Skip now, because focusing on refactoring ADMG, MAG class.")
     def test_is_m_separator(self):
         """


### PR DESCRIPTION
Apply Review

- `add_edge` only receive `edge_type` type to `str`
- Rename from `get_edge_type` to `get_supported_edge_types`
- Create `get_edge_type` to find `edge_type` base on `u`, `v`, `key` params
- Remove long type hint in internal method
- `is_collider` return False when `u` and `v` are neighbor.
- Add test code for above case