### PR TITLE
Implement minimal tabular MLE flow for FunctionalCPD refactor

### DIFF
--- a/pgmpy/factors/hybrid/FunctionalCPD_Refactor.py
+++ b/pgmpy/factors/hybrid/FunctionalCPD_Refactor.py
@@ -1,5 +1,6 @@
 from pgmpy.estimators import MaximumLikelihoodEstimator as MLE
 from pgmpy.factors.base import BaseFactor
+from pgmpy.factors.discrete import TabularCPD
 
 
 class FunctionalCPD(BaseFactor):
@@ -8,8 +9,11 @@ class FunctionalCPD(BaseFactor):
         self.tag = tag
         self.estimator = estimator
 
-    def fit(self, data):
-        self.parents_ = list(self.predecessors(self.variable))
+    def fit(self, data, target=None, parents=None):
+        self.data_ = data
+        self.parents_ = parents if parents is not None else []
+        if target is not None:
+            self.variable = target
         self.tag_name_ = self.tag[0] if isinstance(self.tag, list) else self.tag
 
         if self.tag_name_ == "tabular":
@@ -26,7 +30,30 @@ class FunctionalCPD(BaseFactor):
         return self
 
     def _fit_tabular(self):
-        self.estimator
+        if self.estimator not in ("MLE", MLE):
+            raise ValueError("For tabular tag, only MLE estimator is currently supported.")
 
-        if isinstance(self.estimator, MLE):
-            self.estimator.estimate_cpd(self.variable)
+        variable_states = sorted(self.data_[self.variable].dropna().unique())
+        if not self.parents_:
+            counts = self.data_[self.variable].value_counts().reindex(variable_states, fill_value=0)
+            probs = counts.values / counts.values.sum()
+            values = [[prob] for prob in probs]
+            self.fitted_cpd_ = TabularCPD(variable=self.variable, variable_card=len(variable_states), values=values)
+            return
+
+        parent_states = [sorted(self.data_[parent].dropna().unique()) for parent in self.parents_]
+        grouped = (
+            self.data_.groupby(self.parents_ + [self.variable], dropna=False)
+            .size()
+            .unstack(self.variable, fill_value=0)
+            .reindex(columns=variable_states, fill_value=0)
+        )
+        grouped = grouped.T
+        grouped = grouped / grouped.sum(axis=0).replace(0, 1)
+        self.fitted_cpd_ = TabularCPD(
+            variable=self.variable,
+            variable_card=len(variable_states),
+            values=grouped.values,
+            evidence=self.parents_,
+            evidence_card=[len(states) for states in parent_states],
+        )


### PR DESCRIPTION
## Summary
- completed `_fit_tabular()` in `pgmpy/factors/hybrid/FunctionalCPD_Refactor.py` with a minimal MLE-only implementation
- added support for `estimator="MLE"` (and `MaximumLikelihoodEstimator` class alias)
- built `TabularCPD` from observed frequencies for both:
  - root variables (no parents)
  - conditional variables (with parents)
- store learned CPD on `self.fitted_cpd_`

## Additional small wiring changes
- updated `fit` signature to accept `target` and `parents` used by `FunctionalBayesianNetwork_Refactor.fit`
- save incoming data on `self.data_` and resolve `self.variable` from `target` when provided

## Notes
- this is intentionally minimal POC behavior focused on tabular + MLE only, as requested.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb7ba9b1048327b8331be51e830950)