### PR TITLE
[Refactor] Add POC skpro adapter and external-ML fit path for FunctionalCPD

### DIFF
--- a/pgmpy/factors/hybrid/FunctionalCPD_Refactor.py
+++ b/pgmpy/factors/hybrid/FunctionalCPD_Refactor.py
@@ -4,10 +4,11 @@ from pgmpy.estimators import MaximumLikelihoodEstimator as MLE
 from pgmpy.factors.base import BaseFactor
 from pgmpy.factors.continuous import LinearGaussianCPD
 from pgmpy.factors.discrete import TabularCPD
+from pgmpy.factors.hybrid.SkproAdapter import SkproAdapter
 
 
 class FunctionalCPD(BaseFactor):
-    def __init__(self, variable, tag, estimator):
+    def __init__(self, variable, tag, estimator=None):
         self.variable = variable
         self.tag = tag
         self.estimator = estimator
@@ -25,7 +26,7 @@ class FunctionalCPD(BaseFactor):
             self._fit_linear()
         elif self.tag_name_ == "functional":
             self._fit_functional()
-        elif self.tag_name_ == "skpro":
+        elif self.tag_name_ == "skpro" or self.tag_name_.startswith("skpro."):
             self._fit_external_ml()
 
         self.is_fitted_ = True
@@ -85,6 +86,14 @@ class FunctionalCPD(BaseFactor):
             std = np.sqrt(variance)
 
         self.fitted_cpd_ = LinearGaussianCPD(variable=self.variable, beta=beta, std=std, evidence=self.parents_)
+
+    def _fit_external_ml(self):
+        if self.estimator is None:
+            raise ValueError("For skpro tag, `estimator` must be provided.")
+
+        self.fitted_cpd_ = SkproAdapter(variable=self.variable, model=self.estimator, parents=self.parents_).fit(
+            self.data_
+        )
 
     def __repr__(self):
         if not getattr(self, "is_fitted_", False):

--- a/pgmpy/factors/hybrid/SkproAdapter.py
+++ b/pgmpy/factors/hybrid/SkproAdapter.py
@@ -1,0 +1,22 @@
+class SkproAdapter:
+    """
+    Minimal adapter that wraps external skpro-like estimators.
+    """
+
+    def __init__(self, variable, model, parents=None):
+        self.variable = variable
+        self.model = model
+        self.parents = parents if parents is not None else []
+
+    def fit(self, data):
+        X = data[self.parents] if self.parents else data.iloc[:, 0:0]
+        y = data[self.variable]
+        self.model.fit(X, y)
+        return self
+
+    def __repr__(self):
+        model_name = type(self.model).__name__
+        return (
+            f"<SkproAdapter(variable='{self.variable}', "
+            f"model='{model_name}', parents={self.parents}) at {hex(id(self))}>"
+        )

--- a/pgmpy/models/FunctionalBayesianNetwork_Refactor.py
+++ b/pgmpy/models/FunctionalBayesianNetwork_Refactor.py
@@ -3,7 +3,7 @@ from collections.abc import Hashable, Iterable
 import networkx as nx
 import pandas as pd
 
-from pgmpy.factors.hybrid import FunctionalCPD
+from pgmpy.factors.hybrid.FunctionalCPD_Refactor import FunctionalCPD
 from pgmpy.models import DiscreteBayesianNetwork
 
 

--- a/pgmpy/tests/test_models/test_FunctionalBayesianNetwork_Refactor.py
+++ b/pgmpy/tests/test_models/test_FunctionalBayesianNetwork_Refactor.py
@@ -3,6 +3,7 @@ import pandas as pd
 
 from pgmpy.estimators import MaximumLikelihoodEstimator as MLE
 from pgmpy.factors.hybrid.FunctionalCPD_Refactor import FunctionalCPD
+from pgmpy.factors.hybrid.SkproAdapter import SkproAdapter
 from pgmpy.models.FunctionalBayesianNetwork_Refactor import FunctionalBayesianNetwork as FunctionalBN
 
 
@@ -41,3 +42,41 @@ def test_fit_learns_mixed_tabular_and_linear_cpds():
     np.testing.assert_allclose(fitted_d.beta[0], 0.0, atol=0.25)
     np.testing.assert_allclose(fitted_d.beta[1:], [2.5, -1.5, 3.0], atol=0.2)
     np.testing.assert_allclose(fitted_d.std, 1.0, atol=0.15)
+
+
+class DummySkproRegressor:
+    def fit(self, X, y):
+        self.was_fit = True
+        self.X_shape = X.shape
+        self.y_shape = y.shape
+        self.y_mean = float(np.mean(y))
+        return self
+
+
+def test_fit_uses_skpro_adapter_for_external_model():
+    n_samples = 20
+    rng = np.random.default_rng(11)
+    data = pd.DataFrame(
+        {
+            "A": rng.normal(size=n_samples),
+            "B": rng.normal(size=n_samples),
+            "grade": rng.normal(loc=5.0, scale=1.0, size=n_samples),
+        }
+    )
+
+    model = FunctionalBN([("A", "grade"), ("B", "grade")])
+    cpd_a = FunctionalCPD(variable="A", tag="linear", estimator="MLE")
+    cpd_b = FunctionalCPD(variable="B", tag="linear", estimator="MLE")
+    cpd_grade = FunctionalCPD(
+        variable="grade",
+        tag=["skpro.BayesianLinearRegressor"],
+        estimator=DummySkproRegressor(),
+    )
+    model.add_cpds(cpd_a, cpd_b, cpd_grade)
+    model.fit(data)
+
+    fitted_grade = model.get_cpds("grade")
+    assert isinstance(fitted_grade.fitted_cpd_, SkproAdapter)
+    assert fitted_grade.fitted_cpd_.model.was_fit is True
+    assert fitted_grade.fitted_cpd_.model.X_shape == (n_samples, 2)
+    assert fitted_grade.fitted_cpd_.model.y_shape == (n_samples,)


### PR DESCRIPTION
### Motivation
- Provide a minimal proof-of-concept path to allow `FunctionalCPD` to use external (skpro-like) estimators when a user specifies a `skpro` tag and supplies a model object. 
- Keep the `FunctionalBayesianNetwork` orchestration simple so `model.fit(data)` delegates fitting to each CPD implementation.

### Description
- Implemented `_fit_external_ml()` in `FunctionalCPD_Refactor` to instantiate `SkproAdapter` and run `.fit(X, y)` via the provided `estimator`, and allowed `estimator=None` by default on the CPD constructor. 
- Added `SkproAdapter` (`pgmpy/factors/hybrid/SkproAdapter.py`) which wraps an external estimator and maps parent columns to `X` and the CPD variable to `y` before calling `model.fit(X, y)`. 
- Extended tag handling so `FunctionalCPD_Refactor` recognizes `skpro` and tags starting with `skpro.` (e.g. `tag=['skpro.BayesianLinearRegressor']`). 
- Updated `FunctionalBayesianNetwork_Refactor` to import the refactor CPD class and left `fit` orchestration unchanged so each CPD is responsible for fitting itself. 
- Added a focused test that uses a `DummySkproRegressor` to verify the adapter receives the correct `X`/`y` shapes and that `model.fit(data)` triggers the external fit flow.

### Testing
- Ran `pytest -v pgmpy/tests/test_models/test_FunctionalBayesianNetwork_Refactor.py` and the suite passed (`2 passed`).
- Attempted `pre-commit run --all-files` but the environment lacks `pre-commit` (command not found) so hooks were not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb8c1f1c108327bdcbeec221dcb096)