### PR TITLE
Reivew

### DIFF
--- a/pgmpy/base/PDAG.py
+++ b/pgmpy/base/PDAG.py
@@ -227,7 +227,7 @@ class PDAG(_CoreGraph):
                         if (
                             (not pdag.has_edge(x, z))
                             and (not pdag._check_new_unshielded_collider(y, z))
-                            and (not nx.has_path(pdag._directed_graph(), z, y))
+                            and (not pdag.has_direct_path(z, y))
                         ):
                             pdag.orient_undirected_edge(y, z, inplace=True)
                             changed = True

--- a/pgmpy/base/PDAG.py
+++ b/pgmpy/base/PDAG.py
@@ -144,22 +144,6 @@ class PDAG(_CoreGraph):
         dag = self.to_dag()
         return nx.is_directed_acyclic_graph(dag)
 
-    def _directed_graph(self):
-        """
-        Returns a subgraph containing only directed edges.
-        """
-        ebunch = self.get_edges(data=True)
-        directed_edges = []
-        for u, v, edge_type in ebunch:
-            if edge_type == "->":
-                directed_edges.append((u, v))
-            elif edge_type == "<-":
-                directed_edges.append((v, u))
-
-        dag = nx.DiGraph(directed_edges)
-        dag.add_nodes_from(self.nodes())
-        return dag
-
     def is_clique(self, nodes: Iterable) -> bool:
         """
         Checks if a set of nodes forms a clique. A clique is a subgraph

--- a/pgmpy/base/_base.py
+++ b/pgmpy/base/_base.py
@@ -938,11 +938,7 @@ class _CoreGraph(nx.MultiGraph, _GraphAlgorithmMixin, _GraphRolesMixin):
         if v not in self.get_neighbors(u, "--"):
             raise ValueError(f"Undirected Edge {u} - {v} not present in the PDAG.")
 
-        # Remove the inverse edge from the graph
-        pdag.remove_edge(u, v, "--")
-
-        # Add the edge to directed_edges.
-        pdag.add_edge(u, v, "->")
+        pdag.replace_edge(u, v, "--", "->")
 
         if not inplace:
             return pdag

--- a/pgmpy/base/_base.py
+++ b/pgmpy/base/_base.py
@@ -886,7 +886,7 @@ class _CoreGraph(nx.MultiGraph, _GraphAlgorithmMixin, _GraphRolesMixin):
             pdag = self.copy()
 
         # Remove the edge for undirected_edges.
-        if not (v in self.get_neighbors(u, "--") or u in self.get_neighbors(v, "--")):
+        if v not in self.get_neighbors(u, "--"):
             raise ValueError(f"Undirected Edge {u} - {v} not present in the PDAG.")
 
         # Remove the inverse edge from the graph

--- a/pgmpy/base/_base.py
+++ b/pgmpy/base/_base.py
@@ -906,7 +906,9 @@ class _CoreGraph(nx.MultiGraph, _GraphAlgorithmMixin, _GraphRolesMixin):
         if not self.has_edge(u, v):
             raise ValueError(f"Edge ({u}, {v}) not in graph.")
 
-        # TODO(@daehyun99): Add logic of maintain edge's attr data
+        # TODO: Add logic of maintain edge's attr data
+        #       Currently, we treat `edge_type` as an attribute,
+        #       so additional logic will need to be developed to handle this in the future.
         self.remove_edge(u, v, old_type)
         self.add_edge(u, v, new_type)
 

--- a/pgmpy/base/_base.py
+++ b/pgmpy/base/_base.py
@@ -860,6 +860,55 @@ class _CoreGraph(nx.MultiGraph, _GraphAlgorithmMixin, _GraphRolesMixin):
         edge_type = self._to_api_edge_type(u, v, markers)
         return edge_type
 
+    def replace_edge(
+        self,
+        u: Hashable,
+        v: Hashable,
+        old_type: str = "--",
+        new_type: str = "->",
+    ) -> None:
+        """
+        Replaces the type of an existing edge between two nodes with a new type.
+
+        Parameters
+        ----------
+        u : Hashable
+            The source node of the edge.
+        v : Hashable
+            The target node of the edge.
+        old_type : str, optional (default="--")
+            The current type of the edge that needs to be replaced.
+        new_type : str, optional (default="->")
+            The new edge type to be assigned.
+
+        Returns
+        -------
+        None
+
+        Examples
+        --------
+        >>> from pgmpy.base._base import _CoreGraph
+        >>> graph = _CoreGraph()
+        >>> graph.add_edge("A", "B", "--")
+        >>> graph.replace_edge("A", "B", old_type="--", new_type="->")
+        >>> graph.has_edge("A", "B", "->")
+        True
+        >>> graph.has_edge("A", "B", "--")
+        False
+
+        """
+        if (old_type not in self.SUPPORTED_EDGE_TYPES) or (new_type not in self.SUPPORTED_EDGE_TYPES):
+            raise ValueError(
+                f"Unsupported edge type(s) provided. "
+                f"Got old_type='{old_type}', new_type='{new_type}'. "
+                f"Supported types are: {self.SUPPORTED_EDGE_TYPES}."
+            )
+        if not self.has_edge(u, v):
+            raise ValueError(f"Edge ({u}, {v}) not in graph.")
+
+        self.remove_edge(u, v, old_type)
+        self.add_edge(u, v, new_type)
+
     def orient_undirected_edge(self, u, v, inplace=False):
         """
         Orients an undirected edge u - v as u -> v.

--- a/pgmpy/base/_base.py
+++ b/pgmpy/base/_base.py
@@ -906,6 +906,7 @@ class _CoreGraph(nx.MultiGraph, _GraphAlgorithmMixin, _GraphRolesMixin):
         if not self.has_edge(u, v):
             raise ValueError(f"Edge ({u}, {v}) not in graph.")
 
+        # TODO(@daehyun99): Add logic of maintain edge's attr data
         self.remove_edge(u, v, old_type)
         self.add_edge(u, v, new_type)
 

--- a/pgmpy/base/_mixin_algorithms.py
+++ b/pgmpy/base/_mixin_algorithms.py
@@ -564,6 +564,10 @@ class _GraphAlgorithmMixin:
         True
 
         """
+        # NOTE(@daehyun99): This method will be Refactored when Refactor DAG
+        # dag = self.get_directed_subgraph()
+        # return nx.has_path(dag, u, v)
+
         for path in nx.all_simple_edge_paths(self, u, v):
             is_directed_path = True
             for edge in path:

--- a/pgmpy/base/_mixin_algorithms.py
+++ b/pgmpy/base/_mixin_algorithms.py
@@ -651,7 +651,7 @@ class _GraphAlgorithmMixin:
         # # TODO(@daehyun99): [#2385] Apply type hint(input, output)
         raise NotImplementedError("`has_almost_directed_cycle` is not supported now")
 
-    def _check_new_unshielded_collider(self, u, v):
+    def _check_new_unshielded_collider(self, u: Hashable, v: Hashable) -> bool:
         """
         Tests if orienting an undirected edge u - v as u -> v creates new unshielded V-structures in the PDAG.
 
@@ -662,9 +662,6 @@ class _GraphAlgorithmMixin:
         True, if the orientation u -> v would lead to creation of a new V-structure.
         False, if no new V-structures are formed.
         """
-        # # TODO(@daehyun99): [#2385] Implement code logic and test code
-        # # TODO(@daehyun99): [#2385] Fix Docs (Unify Docs Format)
-        # # TODO(@daehyun99): [#2385] Apply type hint(input, output)
         for node in self.get_parents(v):
             if (node != u) and (not self.has_edge(u, node)):
                 return True

--- a/pgmpy/base/_mixin_algorithms.py
+++ b/pgmpy/base/_mixin_algorithms.py
@@ -6,7 +6,6 @@ import networkx as nx
 
 from pgmpy.utils.types import Self
 
-
 class _GraphAlgorithmMixin:
     """Mixin class for causal graph's algorithms."""
 
@@ -650,6 +649,28 @@ class _GraphAlgorithmMixin:
         # # TODO(@daehyun99): [#2385] Fix Docs (Unify Docs Format)
         # # TODO(@daehyun99): [#2385] Apply type hint(input, output)
         raise NotImplementedError("`has_almost_directed_cycle` is not supported now")
+
+    def get_directed_subgraph(self):
+        """
+        Return a graph with the same nodes as the original graph, but containing only directed edges.
+        """
+        # # TODO(@daehyun99): [#2385] Implement code logic and test code When Refactor DAG
+        # # TODO(@daehyun99): [#2385] Fix Docs (Unify Docs Format)
+        # # TODO(@daehyun99): [#2385] Apply type hint(input, output)
+        ebunch = self.get_edges(data=True)
+        directed_edges = []
+        for u, v, edge_type in ebunch:
+            if edge_type in {"->", "<-"}:
+                directed_edges.append((u, v, edge_type))
+
+        # from pgmpy.base import DAG
+        # TODO(@daehyun99): [#2385] Refactoring _CoreGraph -> DAG when Refactor DAG
+        from pgmpy.base._base import _CoreGraph
+        dag = _CoreGraph(directed_edges)
+        dag.add_nodes_from(self.nodes())
+        for role, vars in self.get_role_dict().items():
+            dag.with_role(role=role, variables=vars, inplace=True)
+        return dag
 
     def _check_new_unshielded_collider(self, u: Hashable, v: Hashable) -> bool:
         """

--- a/pgmpy/base/_mixin_algorithms.py
+++ b/pgmpy/base/_mixin_algorithms.py
@@ -567,6 +567,8 @@ class _GraphAlgorithmMixin:
         """
         # NOTE(@daehyun99): This method will be Refactored when Refactor DAG
         # dag = self.get_directed_subgraph()
+        # dag = nx.DiGraph(self.get_edges())
+        # # NOTE: To use `nx.has_path`, the graph must be an `nx.DiGraph`.
         # return nx.has_path(dag, u, v)
 
         for path in nx.all_simple_edge_paths(self, u, v):
@@ -663,16 +665,16 @@ class _GraphAlgorithmMixin:
         # # TODO(@daehyun99): [#2385] Fix Docs (Unify Docs Format)
         # # TODO(@daehyun99): [#2385] Apply type hint(input, output)
         ebunch = self.get_edges(data=True)
-        directed_edges = []
+        directed_ebunch = []
         for u, v, edge_type in ebunch:
             if edge_type in {"->", "<-"}:
-                directed_edges.append((u, v, edge_type))
+                directed_ebunch.append((u, v, edge_type))
 
         # from pgmpy.base import DAG
         # TODO(@daehyun99): [#2385] Refactoring _CoreGraph -> DAG when Refactor DAG
         from pgmpy.base._base import _CoreGraph
 
-        dag = _CoreGraph(directed_edges)
+        dag = _CoreGraph(directed_ebunch)
         dag.add_nodes_from(self.nodes())
         for role, vars in self.get_role_dict().items():
             dag.with_role(role=role, variables=vars, inplace=True)

--- a/pgmpy/base/_mixin_algorithms.py
+++ b/pgmpy/base/_mixin_algorithms.py
@@ -6,6 +6,7 @@ import networkx as nx
 
 from pgmpy.utils.types import Self
 
+
 class _GraphAlgorithmMixin:
     """Mixin class for causal graph's algorithms."""
 
@@ -670,6 +671,7 @@ class _GraphAlgorithmMixin:
         # from pgmpy.base import DAG
         # TODO(@daehyun99): [#2385] Refactoring _CoreGraph -> DAG when Refactor DAG
         from pgmpy.base._base import _CoreGraph
+
         dag = _CoreGraph(directed_edges)
         dag.add_nodes_from(self.nodes())
         for role, vars in self.get_role_dict().items():

--- a/pgmpy/tests/test_base/test_base.py
+++ b/pgmpy/tests/test_base/test_base.py
@@ -1997,3 +1997,42 @@ class TestCoreGraph:
         assert graph.get_edge_type("A", "B", 6) == "o-"
 
     def test_orient_undirected_edge(self): ...
+
+    def test_replace_edge(self):
+        graph = _CoreGraph()
+        graph.add_edge("A", "B", "--")
+
+        graph.replace_edge("A", "B", old_type="--", new_type="->")
+        assert graph.get_edges(keys=False, data=True) == (
+            [
+                ("A", "B", "->"),
+            ]
+        )
+
+        graph.replace_edge("A", "B", old_type="->", new_type="<>")
+        assert graph.get_edges(keys=False, data=True) == (
+            [
+                ("A", "B", "<>"),
+            ]
+        )
+
+        graph.replace_edge("A", "B", old_type="<>", new_type="oo")
+        assert graph.get_edges(keys=False, data=True) == (
+            [
+                ("A", "B", "oo"),
+            ]
+        )
+
+    def test_replace_edge_fails(self):
+        graph = _CoreGraph()
+        graph.add_node("C")
+        graph.add_edge("A", "B", "--")
+
+        with pytest.raises(ValueError):
+            graph.replace_edge("A", "B", old_type="!!", new_type="->")
+
+        with pytest.raises(ValueError):
+            graph.replace_edge("A", "B", old_type="--", new_type="~~")
+
+        with pytest.raises(ValueError):
+            graph.replace_edge("B", "C", old_type="--", new_type="->")

--- a/pgmpy/tests/test_base/test_mixin_algorithms.py
+++ b/pgmpy/tests/test_base/test_mixin_algorithms.py
@@ -590,4 +590,15 @@ class TestGraphAlgorithmMixin:
         assert nx.has_path(graph, "A", "D") is True
         assert graph.has_direct_path("A", "D") is True
 
-    def test_check_new_unshielded_collider(self): ...
+    def test_check_new_unshielded_collider(self):
+        graph = _CoreGraph()
+
+        graph.add_edge("A", "B", "->")
+        graph.add_edge("B", "C", "--")
+
+        assert graph._check_new_unshielded_collider(u="C", v="B") is True
+        assert graph._check_new_unshielded_collider(u="B", v="C") is False
+
+        graph.add_edge("A", "C", "--")
+
+        assert graph._check_new_unshielded_collider(u="C", v="B") is False

--- a/pgmpy/tests/test_base/test_mixin_algorithms.py
+++ b/pgmpy/tests/test_base/test_mixin_algorithms.py
@@ -614,7 +614,9 @@ class TestGraphAlgorithmMixin:
 
         subgraph = graph.get_directed_subgraph()
 
-        assert isinstance(subgraph, _CoreGraph) # TODO(@daehyun99): [#2385] Refactoring _CoreGraph -> DAG when Refactor DAG
+        assert isinstance(
+            subgraph, _CoreGraph
+        )  # TODO(@daehyun99): [#2385] Refactoring _CoreGraph -> DAG when Refactor DAG
         assert set(subgraph.nodes()) == {"A", "B", "C", "D", "E"}
         assert set(subgraph.get_edges(keys=True, data=True)) == {("A", "B", 0, "->"), ("B", "C", 0, "->")}
         assert subgraph.latents == {"E"}

--- a/pgmpy/tests/test_base/test_mixin_algorithms.py
+++ b/pgmpy/tests/test_base/test_mixin_algorithms.py
@@ -602,3 +602,19 @@ class TestGraphAlgorithmMixin:
         graph.add_edge("A", "C", "--")
 
         assert graph._check_new_unshielded_collider(u="C", v="B") is False
+
+    def test_get_directed_subgraph(self):
+        graph = _CoreGraph()
+
+        graph.add_edge("A", "B", "->")
+        graph.add_edge("B", "C", "->")
+        graph.add_edge("C", "D", "<>")
+        graph.add_edge("D", "E", "--")
+        graph.latents = "E"
+
+        subgraph = graph.get_directed_subgraph()
+
+        assert isinstance(subgraph, _CoreGraph) # TODO(@daehyun99): [#2385] Refactoring _CoreGraph -> DAG when Refactor DAG
+        assert set(subgraph.nodes()) == {"A", "B", "C", "D", "E"}
+        assert set(subgraph.get_edges(keys=True, data=True)) == {("A", "B", 0, "->"), ("B", "C", 0, "->")}
+        assert subgraph.latents == {"E"}


### PR DESCRIPTION
- Refactor: ENH logic of `orient_undirected_edge`
- MNT: add type hint for `_check_new_unshielded_collider`
- Test: add test code for `_check_new_unshielded_collider`
- Feat: Implement `replace_edge` in `_CoreGraph`
- Refactor: Refactor `orient_undirected_edge`, `apply_meeks_rules`
- Refactor: `PDAG._directed_graph` -> `_GraphAlgorithmMixin.get_directed_subgraph`
- ENH: Optimize performance of `has_direct_path`
- MNT: Add comments