### PR TITLE
Add skpro-compatible TabularCPD API and Categorical distribution

### DIFF
--- a/pgmpy/distribution/__init__.py
+++ b/pgmpy/distribution/__init__.py
@@ -1,0 +1,3 @@
+from .categorical import Categorical
+
+__all__ = ["Categorical"]

--- a/pgmpy/distribution/categorical.py
+++ b/pgmpy/distribution/categorical.py
@@ -1,0 +1,24 @@
+import numpy as np
+
+
+class Categorical:
+    """Categorical distribution container compatible with CPD predictions."""
+
+    def __init__(self, classes, probs):
+        self.classes = list(classes)
+        self.probs = np.asarray(probs, dtype=float)
+
+        if self.probs.ndim == 1:
+            self.probs = self.probs.reshape(1, -1)
+
+        if self.probs.ndim != 2:
+            raise ValueError("probs must be a 1D or 2D array-like object.")
+
+        if self.probs.shape[1] != len(self.classes):
+            raise ValueError("Number of probability columns must match number of classes.")
+
+    def mean(self):
+        return self.probs
+
+    def mode(self):
+        return np.array([self.classes[i] for i in np.argmax(self.probs, axis=1)])

--- a/pgmpy/factors/discrete/CPD.py
+++ b/pgmpy/factors/discrete/CPD.py
@@ -12,6 +12,7 @@ import numpy as np
 import pandas as pd
 
 from pgmpy import config, logger
+from pgmpy.distribution import Categorical
 from pgmpy.extern import tabulate
 from pgmpy.factors.discrete import DiscreteFactor
 from pgmpy.utils import compat_fns
@@ -208,6 +209,106 @@ class TabularCPD(DiscreteFactor):
             return self.values.reshape(tuple([self.cardinality[0], np.prod(self.cardinality[1:])]))
         else:
             return self.values.reshape(tuple([np.prod(self.cardinality), 1]))
+
+
+    def fit(self, X: pd.DataFrame, y: pd.Series | np.ndarray | None = None):
+        """Estimate CPD values from data.
+
+        Parameters
+        ----------
+        X: pandas.DataFrame
+            DataFrame containing evidence columns. If `y` is None, must also contain
+            the target variable column.
+
+        y: array-like, optional
+            Target variable samples for `self.variable`.
+
+        Returns
+        -------
+        TabularCPD
+            Returns self for estimator-style chaining.
+        """
+        if not isinstance(X, pd.DataFrame):
+            raise TypeError("X must be a pandas DataFrame.")
+
+        evidence = self.variables[1:]
+
+        if y is None:
+            required = [self.variable] + evidence
+            missing = [col for col in required if col not in X.columns]
+            if missing:
+                raise ValueError(f"Missing required columns in X: {missing}")
+            data = X[required].copy()
+        else:
+            missing = [col for col in evidence if col not in X.columns]
+            if missing:
+                raise ValueError(f"Missing evidence columns in X: {missing}")
+            data = X[evidence].copy()
+            data[self.variable] = y
+
+        if self.state_names:
+            for var in self.variables:
+                if var in self.state_names:
+                    data[var] = pd.Categorical(data[var], categories=self.state_names[var], ordered=False)
+
+        counts = pd.crosstab(
+            index=data[self.variable],
+            columns=[data[var] for var in evidence] if evidence else None,
+            dropna=False,
+        )
+
+        if not evidence:
+            counts = counts.to_frame()
+
+        counts = counts.reindex(index=self.state_names[self.variable], fill_value=0)
+
+        if evidence:
+            full_columns = pd.MultiIndex.from_product([self.state_names[var] for var in evidence], names=evidence)
+            counts = counts.reindex(columns=full_columns, fill_value=0)
+
+        probs = counts.to_numpy(dtype=float)
+        column_sums = probs.sum(axis=0, keepdims=True)
+        valid = column_sums > 0
+        probs[:, valid[0]] = probs[:, valid[0]] / column_sums[:, valid[0]]
+
+        self.values = probs.reshape(tuple(self.cardinality))
+        return self
+
+    def predict_proba(self, X: pd.DataFrame | None = None):
+        """Return a Categorical distribution for each sample in X."""
+        evidence = self.variables[1:]
+        values_2d = compat_fns.to_numpy(self.get_values()).T
+
+        if not evidence:
+            probs = values_2d
+            n_rows = 1 if X is None else len(X)
+            probs = np.repeat(probs, n_rows, axis=0)
+            return Categorical(classes=self.state_names[self.variable], probs=probs)
+
+        if X is None:
+            raise ValueError("X must be provided for CPDs with evidence variables.")
+
+        if not isinstance(X, pd.DataFrame):
+            raise TypeError("X must be a pandas DataFrame.")
+
+        missing = [col for col in evidence if col not in X.columns]
+        if missing:
+            raise ValueError(f"Missing evidence columns in X: {missing}")
+
+        index_map = {}
+        for col_idx, states in enumerate(product(*[self.state_names[var] for var in evidence])):
+            index_map[states] = col_idx
+
+        probs = []
+        for _, row in X[evidence].iterrows():
+            key = tuple(row[var] for var in evidence)
+            probs.append(values_2d[index_map[key]])
+
+        return Categorical(classes=self.state_names[self.variable], probs=np.vstack(probs))
+
+    def predict(self, X: pd.DataFrame | None = None):
+        """Predict the most probable state for each sample."""
+        return self.predict_proba(X).mode()
 
     def __str__(self):
         return self._make_table_str(tablefmt="grid")

--- a/pgmpy/tests/test_factors/test_discrete/test_CPD_skpro_api.py
+++ b/pgmpy/tests/test_factors/test_discrete/test_CPD_skpro_api.py
@@ -1,0 +1,61 @@
+import numpy as np
+import pandas as pd
+
+from pgmpy.distribution import Categorical
+from pgmpy.factors.discrete import TabularCPD
+
+
+def test_predict_proba_returns_categorical_distribution():
+    cpd = TabularCPD(
+        variable="grade",
+        variable_card=2,
+        values=[[0.7, 0.2], [0.3, 0.8]],
+        evidence=["diff"],
+        evidence_card=[2],
+        state_names={"grade": ["A", "B"], "diff": ["easy", "hard"]},
+    )
+
+    X = pd.DataFrame({"diff": ["easy", "hard", "hard"]})
+    pred_dist = cpd.predict_proba(X)
+
+    assert isinstance(pred_dist, Categorical)
+    np.testing.assert_allclose(pred_dist.mean(), np.array([[0.7, 0.3], [0.2, 0.8], [0.2, 0.8]]))
+
+
+def test_predict_returns_mode_states():
+    cpd = TabularCPD(
+        variable="grade",
+        variable_card=2,
+        values=[[0.7, 0.2], [0.3, 0.8]],
+        evidence=["diff"],
+        evidence_card=[2],
+        state_names={"grade": ["A", "B"], "diff": ["easy", "hard"]},
+    )
+
+    X = pd.DataFrame({"diff": ["easy", "hard"]})
+    pred = cpd.predict(X)
+
+    assert list(pred) == ["A", "B"]
+
+
+def test_fit_updates_cpd_from_data():
+    cpd = TabularCPD(
+        variable="grade",
+        variable_card=2,
+        values=[[0.5, 0.5], [0.5, 0.5]],
+        evidence=["diff"],
+        evidence_card=[2],
+        state_names={"grade": ["A", "B"], "diff": ["easy", "hard"]},
+    )
+
+    data = pd.DataFrame(
+        {
+            "diff": ["easy", "easy", "hard", "hard", "hard"],
+            "grade": ["A", "A", "A", "B", "B"],
+        }
+    )
+
+    cpd.fit(data)
+
+    expected = np.array([[1.0, 1 / 3], [0.0, 2 / 3]])
+    np.testing.assert_allclose(cpd.get_values(), expected)


### PR DESCRIPTION
### Motivation
- Provide skpro-style estimator interoperability so CPDs can be swapped with skpro models during parameter learning.
- Return a distribution object from CPD predictions to match skpro semantics and make downstream code more uniform.

### Description
- Added a new `pgmpy.distribution` package and implemented a `Categorical` distribution container with `mean()` and `mode()` accessors.
- Extended `TabularCPD` with estimator-like methods: `fit`, `predict_proba`, and `predict`, and updated `predict_proba` to return a `Categorical` instance.
- Updated imports in `pgmpy/factors/discrete/CPD.py` to use the new `Categorical` class and added evidence-handling logic for prediction and fitting.
- Added pytest coverage in `pgmpy/tests/test_factors/test_discrete/test_CPD_skpro_api.py` to validate `predict_proba` return type and probabilities, `predict` mode selection, and `fit`-based CPD updates.

### Testing
- Ran `pytest -v pgmpy/tests/test_factors/test_discrete/test_CPD_skpro_api.py` which failed during collection with `PackageNotFoundError` because local package metadata for `pgmpy` was not available in the environment.
- Attempted to prepare the environment with `pip install -e .` which failed while installing build dependencies due to inability to fetch `setuptools>=61.0` (network/proxy restrictions), preventing full test execution.
- The new tests were added and committed but could not be executed end-to-end in this environment due to the above packaging/install limitations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2fa7acbb483279b86ca296f70bcf8)