### PR TITLE
Make Categorical skpro-compatible and add `sample()` / `plot()` APIs

### DIFF
--- a/pgmpy/distribution/categorical.py
+++ b/pgmpy/distribution/categorical.py
@@ -1,7 +1,14 @@
+from __future__ import annotations
+
 import numpy as np
 
+try:
+    from skpro.distributions.base import BaseDistribution as _SkproBaseDistribution
+except ImportError:  # pragma: no cover - optional dependency
+    _SkproBaseDistribution = object
 
-class Categorical:
+
+class Categorical(_SkproBaseDistribution):
     """Categorical distribution container compatible with CPD predictions."""
 
     def __init__(self, classes, probs):
@@ -22,3 +29,28 @@ class Categorical:
 
     def mode(self):
         return np.array([self.classes[i] for i in np.argmax(self.probs, axis=1)])
+
+    def sample(self, n_samples=1, random_state=None):
+        """Sample class labels from each row-wise categorical distribution."""
+        rng = np.random.default_rng(random_state)
+        n_rows = self.probs.shape[0]
+        samples = np.empty((n_rows, n_samples), dtype=object)
+        for i in range(n_rows):
+            samples[i, :] = rng.choice(self.classes, size=n_samples, p=self.probs[i])
+        return samples
+
+    def plot(self, row=0, ax=None):
+        """Plot category probabilities for a selected row."""
+        import matplotlib.pyplot as plt
+
+        if not 0 <= row < self.probs.shape[0]:
+            raise IndexError("row is out of bounds for probability matrix.")
+
+        if ax is None:
+            _, ax = plt.subplots()
+
+        ax.bar(self.classes, self.probs[row])
+        ax.set_ylim(0, 1)
+        ax.set_ylabel("Probability")
+        ax.set_title(f"Categorical distribution (row={row})")
+        return ax

--- a/pgmpy/tests/test_factors/test_discrete/test_CPD_skpro_api.py
+++ b/pgmpy/tests/test_factors/test_discrete/test_CPD_skpro_api.py
@@ -59,3 +59,23 @@ def test_fit_updates_cpd_from_data():
 
     expected = np.array([[1.0, 1 / 3], [0.0, 2 / 3]])
     np.testing.assert_allclose(cpd.get_values(), expected)
+
+
+
+def test_categorical_sample_shape_and_values():
+    dist = Categorical(classes=["A", "B"], probs=[[0.7, 0.3], [0.2, 0.8]])
+    samples = dist.sample(n_samples=5, random_state=7)
+
+    assert samples.shape == (2, 5)
+    assert set(np.unique(samples)).issubset({"A", "B"})
+
+
+def test_categorical_plot_returns_axes():
+    import matplotlib
+
+    matplotlib.use("Agg")
+
+    dist = Categorical(classes=["A", "B"], probs=[0.7, 0.3])
+    ax = dist.plot()
+
+    assert ax.get_ylabel() == "Probability"


### PR DESCRIPTION
### Motivation
- Provide compatibility with the `skpro` distribution API by having `Categorical` inherit from `skpro.distributions.base.BaseDistribution` when available to integrate CPD predictions with external tooling.
- Expose common distribution utilities (`sample()` and `plot()`) so CPD prediction objects can be sampled and visualized directly from the `Categorical` container.

### Description
- Make `pgmpy.distribution.Categorical` conditionally inherit from `skpro.distributions.base.BaseDistribution` and fall back to `object` when `skpro` is not installed by using a guarded `ImportError` import.
- Implement `sample(self, n_samples=1, random_state=None)` that uses `numpy.random.default_rng` to draw row-wise categorical samples with reproducible RNG support and returns an array of shape `(n_rows, n_samples)`.
- Implement `plot(self, row=0, ax=None)` which builds a bar plot of class probabilities for the requested row using `matplotlib` and returns the `Axes` object.
- Add tests to `pgmpy/tests/test_factors/test_discrete/test_CPD_skpro_api.py` for `sample()` shape/value domain and for `plot()` returning an `Axes` with the expected ylabel.

### Testing
- Ran the focused test file with `pytest -q pgmpy/tests/test_factors/test_discrete/test_CPD_skpro_api.py`, but collection failed with `importlib.metadata.PackageNotFoundError: No package metadata was found for pgmpy` so tests could not be executed to completion.
- Attempted `pip install -e .` to make an editable install for proper test execution, but the install failed in this environment due to network/proxy restrictions resolving build dependencies (error finding `setuptools>=61.0`).
- The new unit tests were added and are ready to run in an environment where an editable install or normal test execution is possible, and they are expected to validate `sample()` and `plot()` behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2fcfdc8bc8327b0360e871b95cc21)