### PR TITLE
Make TabularCPD inherit BaseEstimator for estimator-style API

### DIFF
--- a/pgmpy/factors/discrete/CPD.py
+++ b/pgmpy/factors/discrete/CPD.py
@@ -10,6 +10,7 @@ from shutil import get_terminal_size
 
 import numpy as np
 import pandas as pd
+from skbase.base import BaseEstimator
 
 from pgmpy import config, logger
 from pgmpy.distribution import Categorical
@@ -18,7 +19,7 @@ from pgmpy.factors.discrete import DiscreteFactor
 from pgmpy.utils import compat_fns
 
 
-class TabularCPD(DiscreteFactor):
+class TabularCPD(DiscreteFactor, BaseEstimator):
     """
     Defines the conditional probability distribution table (CPD table)
 
@@ -171,6 +172,7 @@ class TabularCPD(DiscreteFactor):
         if not isinstance(state_names, dict):
             raise ValueError(f"state_names must be of type dict. Got {type(state_names)}")
 
+        BaseEstimator.__init__(self)
         super().__init__(variables, cardinality, values_casted.flatten(), state_names=state_names)
 
     def __repr__(self):

--- a/pgmpy/tests/test_factors/test_discrete/test_CPD_skpro_api.py
+++ b/pgmpy/tests/test_factors/test_discrete/test_CPD_skpro_api.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+from skbase.base import BaseEstimator
 
 from pgmpy.distribution import Categorical
 from pgmpy.factors.discrete import TabularCPD
@@ -59,3 +60,14 @@ def test_fit_updates_cpd_from_data():
 
     expected = np.array([[1.0, 1 / 3], [0.0, 2 / 3]])
     np.testing.assert_allclose(cpd.get_values(), expected)
+
+
+def test_tabular_cpd_is_base_estimator():
+    cpd = TabularCPD(
+        variable="grade",
+        variable_card=2,
+        values=[[0.7], [0.3]],
+        state_names={"grade": ["A", "B"]},
+    )
+
+    assert isinstance(cpd, BaseEstimator)


### PR DESCRIPTION
### Motivation
- Make `TabularCPD` expose an estimator-style API compatible with the skpro/skbase estimator ecosystem so it can be used like other estimators (e.g. support `fit`/`predict_proba` semantics and tagging). 

### Description
- `TabularCPD` now imports and inherits from `skbase.base.BaseEstimator`, calls `BaseEstimator.__init__(self)` in `__init__`, and a small test was added asserting `TabularCPD` is an instance of `BaseEstimator` (`pgmpy/factors/discrete/CPD.py` and `pgmpy/tests/test_factors/test_discrete/test_CPD_skpro_api.py`).

### Testing
- Verified bytecode compilation with `python -m compileall pgmpy/factors/discrete/CPD.py pgmpy/tests/test_factors/test_discrete/test_CPD_skpro_api.py` (succeeded); attempted `pytest -q pgmpy/tests/test_factors/test_discrete/test_CPD_skpro_api.py` but test collection failed with `PackageNotFoundError` due to missing local `pgmpy` package metadata; attempted `pip install -e .` to fix metadata but the editable install failed due to unavailable build dependency downloads in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2fd443cc0832794a7b5536d5c4035)