### PR TITLE
Delegate TabularCPD.fit to DiscreteMLE estimator

### DIFF
--- a/pgmpy/factors/discrete/CPD.py
+++ b/pgmpy/factors/discrete/CPD.py
@@ -233,6 +233,9 @@ class TabularCPD(DiscreteFactor, BaseEstimator):
         if not isinstance(X, pd.DataFrame):
             raise TypeError("X must be a pandas DataFrame.")
 
+        from pgmpy.base import DAG
+        from pgmpy.parameter_estimator import DiscreteMLE
+
         evidence = self.variables[1:]
 
         if y is None:
@@ -248,32 +251,18 @@ class TabularCPD(DiscreteFactor, BaseEstimator):
             data = X[evidence].copy()
             data[self.variable] = y
 
-        if self.state_names:
-            for var in self.variables:
-                if var in self.state_names:
-                    data[var] = pd.Categorical(data[var], categories=self.state_names[var], ordered=False)
+        model = DAG()
+        model.add_node(self.variable)
+        model.add_nodes_from(evidence)
+        model.add_edges_from((ev, self.variable) for ev in evidence)
 
-        counts = pd.crosstab(
-            index=data[self.variable],
-            columns=[data[var] for var in evidence] if evidence else None,
-            dropna=False,
+        fitted_cpd = DiscreteMLE._estimate_cpd(
+            model=model, data=data, state_names=self.state_names, node=self.variable
         )
+        if evidence and fitted_cpd.variables[1:] != evidence:
+            fitted_cpd = fitted_cpd.reorder_parents(new_order=evidence, inplace=False)
 
-        if not evidence:
-            counts = counts.to_frame()
-
-        counts = counts.reindex(index=self.state_names[self.variable], fill_value=0)
-
-        if evidence:
-            full_columns = pd.MultiIndex.from_product([self.state_names[var] for var in evidence], names=evidence)
-            counts = counts.reindex(columns=full_columns, fill_value=0)
-
-        probs = counts.to_numpy(dtype=float)
-        column_sums = probs.sum(axis=0, keepdims=True)
-        valid = column_sums > 0
-        probs[:, valid[0]] = probs[:, valid[0]] / column_sums[:, valid[0]]
-
-        self.values = probs.reshape(tuple(self.cardinality))
+        self.values = fitted_cpd.values.reshape(tuple(self.cardinality))
         return self
 
     def predict_proba(self, X: pd.DataFrame | None = None):

--- a/pgmpy/tests/test_factors/test_discrete/test_CPD_skpro_api.py
+++ b/pgmpy/tests/test_factors/test_discrete/test_CPD_skpro_api.py
@@ -4,6 +4,7 @@ from skbase.base import BaseEstimator
 
 from pgmpy.distribution import Categorical
 from pgmpy.factors.discrete import TabularCPD
+from pgmpy.parameter_estimator import DiscreteMLE
 
 
 def test_predict_proba_returns_categorical_distribution():
@@ -60,6 +61,29 @@ def test_fit_updates_cpd_from_data():
 
     expected = np.array([[1.0, 1 / 3], [0.0, 2 / 3]])
     np.testing.assert_allclose(cpd.get_values(), expected)
+
+
+def test_fit_delegates_to_discrete_mle_estimator(monkeypatch):
+    cpd = TabularCPD(
+        variable="grade",
+        variable_card=2,
+        values=[[0.5, 0.5], [0.5, 0.5]],
+        evidence=["diff"],
+        evidence_card=[2],
+        state_names={"grade": ["A", "B"], "diff": ["easy", "hard"]},
+    )
+    data = pd.DataFrame({"diff": ["easy", "hard"], "grade": ["A", "B"]})
+    called = {"value": False}
+
+    original_estimate_cpd = DiscreteMLE._estimate_cpd
+
+    def wrapped(*args, **kwargs):
+        called["value"] = True
+        return original_estimate_cpd(*args, **kwargs)
+
+    monkeypatch.setattr(DiscreteMLE, "_estimate_cpd", wrapped)
+    cpd.fit(data)
+    assert called["value"]
 
 
 def test_tabular_cpd_is_base_estimator():


### PR DESCRIPTION
### Motivation
- Replace inline counting/normalization logic in `TabularCPD.fit` with the canonical estimator layer so CPD learning is centralized in `pgmpy.parameter_estimator`.
- Ensure behavior remains consistent (including parent ordering and state-name handling) while reusing existing, tested estimator implementations.

### Description
- Reworked `TabularCPD.fit` to construct a lightweight `DAG` for the target variable and its evidences, and call `DiscreteMLE._estimate_cpd` to compute the fitted CPD.
- If the estimator returns parent ordering different from the original `TabularCPD` evidence order, the fitted CPD is adjusted using `reorder_parents` before copying values back into `self.values`.
- Preserved input validation and the `y`-handling branch so `fit` accepts either `X` containing the target or `X` plus `y` as before.
- Added a unit test `test_fit_delegates_to_discrete_mle_estimator` that monkeypatches `DiscreteMLE._estimate_cpd` to assert that `TabularCPD.fit` delegates to the estimator.

### Testing
- Ran `pytest -v pgmpy/tests/test_factors/test_discrete/test_CPD_skpro_api.py`, which errored during collection due to missing installed `pgmpy` package metadata (`PackageNotFoundError`), so the test could not be executed in this environment.
- Attempted `pip install -e .` to provide package metadata, but installation failed due to network/proxy restrictions when resolving build dependencies (failure to fetch `setuptools>=61.0`).
- Performed `python -m compileall` on the modified files (`pgmpy/factors/discrete/CPD.py` and the updated test file), which succeeded as a syntax check.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2fe2db188832794a127fd11e973e5)