### PR TITLE
Add HybridEstimator orchestration for mixed CPD models

### DIFF
--- a/pgmpy/parameter_estimator/__init__.py
+++ b/pgmpy/parameter_estimator/__init__.py
@@ -3,6 +3,7 @@ from .discrete_bayesian import DiscreteBayesianEstimator
 from .discrete_em import DiscreteEM
 from .discrete_mle import DiscreteMLE
 from .linear_gaussian_mle import LinearGaussianMLE
+from .hybrid import HybridEstimator
 
 __all__ = [
     "BaseParameterEstimator",
@@ -12,4 +13,5 @@ __all__ = [
     "DiscreteBayesianEstimator",
     "DiscreteEM",
     "LinearGaussianMLE",
+    "HybridEstimator",
 ]

--- a/pgmpy/parameter_estimator/hybrid.py
+++ b/pgmpy/parameter_estimator/hybrid.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from .base import BaseParameterEstimator
+
+
+class HybridEstimator(BaseParameterEstimator):
+    """Orchestrates parameter fitting for mixed CPD/model objects in a Bayesian network.
+
+    The estimator expects a model that stores CPD-like objects in ``model.cpds`` and each
+    CPD-like object to expose a ``fit`` method. This allows combining discrete
+    ``TabularCPD`` objects with continuous/skpro-style regressors in a single model.
+
+    Parameters
+    ----------
+    fit_dispatch: dict, optional
+        Mapping of CPD/model types to custom fit callables. Callable signature must be
+        ``callable(cpd, data)`` and should return the fitted CPD/model object. If a CPD's
+        type is not present in this mapping, ``cpd.fit(data)`` is used.
+    """
+
+    _tags = {
+        "supported_model_types": (),
+        "supports_weighted_data": False,
+    }
+
+    def __init__(self, fit_dispatch: dict[type, Callable] | None = None) -> None:
+        self.fit_dispatch = fit_dispatch
+        super().__init__()
+
+    def _validate_inputs(self, model, data, sample_weight=None):
+        if sample_weight is not None:
+            raise ValueError("HybridEstimator does not support `sample_weight`.")
+
+        if not hasattr(model, "cpds"):
+            raise ValueError("model must define a `cpds` attribute containing CPD-like objects.")
+
+        if len(model.cpds) == 0:
+            raise ValueError("model.cpds is empty. Add CPD-like objects before fitting.")
+
+        missing_fit = [cpd for cpd in model.cpds if not hasattr(cpd, "fit")]
+        if missing_fit:
+            raise ValueError("All objects in model.cpds must implement a `fit` method.")
+
+        return model, None
+
+    def _fit_single(self, cpd, data):
+        dispatch = self.fit_dispatch if isinstance(self.fit_dispatch, dict) else {}
+        fit_fn = next((fn for cpd_type, fn in dispatch.items() if isinstance(cpd, cpd_type)), None)
+
+        if fit_fn is not None:
+            return fit_fn(cpd, data)
+
+        cpd.fit(data)
+        return cpd
+
+    def fit(self, model, data, sample_weight=None):
+        """Fit all CPD-like objects in ``model.cpds`` on ``data``.
+
+        Parameters
+        ----------
+        model: object
+            A Bayesian-network-like model object with a ``cpds`` list.
+
+        data: pandas.DataFrame
+            Training data used by each CPD/model object's ``fit`` implementation.
+
+        sample_weight: optional
+            Not supported.
+
+        Returns
+        -------
+        self
+            Fitted estimator with learned parameters in ``parameters_``.
+        """
+        self._model, _ = self._validate_inputs(model, data, sample_weight=sample_weight)
+        self._data = data
+
+        self.parameters_ = [self._fit_single(cpd, data) for cpd in self._model.cpds]
+        return self

--- a/pgmpy/tests/test_parameter_estimator/test_HybridEstimator.py
+++ b/pgmpy/tests/test_parameter_estimator/test_HybridEstimator.py
@@ -1,0 +1,47 @@
+import pandas as pd
+import pytest
+
+from pgmpy.factors.discrete import TabularCPD
+from pgmpy.models.Refactored_BayesianNetwork import BayesianNetwork
+from pgmpy.parameter_estimator import HybridEstimator
+
+
+class DummyRegressor:
+    def __init__(self, variable):
+        self.variable = variable
+        self.fit_called = False
+
+    def fit(self, X):
+        self.fit_called = True
+        self.seen_columns = list(X.columns)
+        return self
+
+
+def test_hybrid_estimator_fits_tabular_and_custom_models():
+    model = BayesianNetwork(ebunch=[("diff", "grade"), ("grade", "score")])
+    cpd_grade = TabularCPD(
+        variable="grade",
+        variable_card=2,
+        values=[[0.5, 0.5], [0.5, 0.5]],
+        evidence=["diff"],
+        evidence_card=[2],
+    )
+    cpd_score = DummyRegressor(variable="score")
+    model.cpds = [cpd_grade, cpd_score]
+
+    data = pd.DataFrame({"diff": [0, 1, 0, 1], "grade": [1, 0, 1, 0], "score": [5.2, 3.4, 6.1, 2.9]})
+
+    est = HybridEstimator()
+    est.fit(model, data)
+
+    assert len(est.parameters_) == 2
+    assert est.parameters_[0].variable == "grade"
+    assert est.parameters_[1].fit_called is True
+
+
+def test_hybrid_estimator_raises_with_empty_cpds():
+    model = BayesianNetwork(ebunch=[("a", "b")])
+    data = pd.DataFrame({"a": [0, 1], "b": [1, 0]})
+
+    with pytest.raises(ValueError, match="model.cpds is empty"):
+        HybridEstimator().fit(model, data)


### PR DESCRIPTION
### Motivation
- Enable parameter learning for Bayesian networks that mix discrete `TabularCPD` objects with custom/skpro-style regressors by providing a single orchestration layer for fitting heterogeneous CPD-like objects.
- Provide a simple extensible dispatch mechanism so custom CPD/model types can be handled differently when required.

### Description
- Add `HybridEstimator` in `pgmpy/parameter_estimator/hybrid.py` which iterates `model.cpds`, validates their interface, and fits each CPD via `cpd.fit(data)` or a user-supplied `fit_dispatch` mapping for type-based custom handlers.
- Implement input validation that requires `model.cpds` to exist and be non-empty, rejects `sample_weight`, and ensures every CPD-like object implements `fit`.
- Export `HybridEstimator` from `pgmpy/parameter_estimator/__init__.py` so it is available as `pgmpy.parameter_estimator.HybridEstimator`.
- Add focused tests in `pgmpy/tests/test_parameter_estimator/test_HybridEstimator.py` covering mixed `TabularCPD + DummyRegressor` fitting and the empty-`cpds` validation case.

### Testing
- Ran `pytest -q pgmpy/tests/test_parameter_estimator/test_HybridEstimator.py` after installing the package; final run succeeded with `2 passed`.
- An initial test collection attempt failed with `ModuleNotFoundError` because the package was not installed, which was resolved by running `pip install -e . --no-build-isolation` prior to the successful test run.
- The new tests verify both successful fitting of mixed CPD objects and that an empty `model.cpds` raises `ValueError`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f30518f8c483278ae519efd750c0c7)