### PR TITLE
Add hybrid parameter-learning notebook for Refactored BayesianNetwork

### DIFF
--- a/examples/Hybrid_Parameter_Learning_Refactored_BN.ipynb
+++ b/examples/Hybrid_Parameter_Learning_Refactored_BN.ipynb
@@ -1,0 +1,175 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Hybrid parameter learning with Refactored BayesianNetwork\n",
+        "\n",
+        "This notebook demonstrates how to:\n",
+        "1. Build a `BayesianNetwork` from `pgmpy/models/Refactored_BayesianNetwork.py` with edges `A -> B`, `B -> C`, and `D -> C`.\n",
+        "2. Use `TabularCPD` for one node and a custom `skpro`-style GAM CPD wrapper for another node.\n",
+        "3. Fit both CPDs together via `HybridEstimator` in `pgmpy.parameter_estimator`.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import numpy as np\n",
+        "import pandas as pd\n",
+        "\n",
+        "from pgmpy.factors.discrete import TabularCPD\n",
+        "from pgmpy.models.Refactored_BayesianNetwork import BayesianNetwork\n",
+        "from pgmpy.parameter_estimator import HybridEstimator\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# 1) Create the structure: A -> B, B -> C, D -> C\n",
+        "model = BayesianNetwork(ebunch=[(\"A\", \"B\"), (\"B\", \"C\"), (\"D\", \"C\")])\n",
+        "model.nodes(), model.edges()\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# 2) Define CPDs/models\n",
+        "# Discrete CPD for B conditioned on A.\n",
+        "cpd_b = TabularCPD(\n",
+        "    variable=\"B\",\n",
+        "    variable_card=2,\n",
+        "    values=[[0.8, 0.3], [0.2, 0.7]],\n",
+        "    evidence=[\"A\"],\n",
+        "    evidence_card=[2],\n",
+        ")\n",
+        "\n",
+        "class SkproGAMCPD:\n",
+        "    \"\"\"CPD-like wrapper around an skpro GAM model for node C.\n",
+        "\n",
+        "    This wrapper exposes `variable`, `get_evidence`, and `fit(data)` so that\n",
+        "    it can be consumed by `HybridEstimator`.\n",
+        "    \"\"\"\n",
+        "\n",
+        "    def __init__(self, variable, evidence):\n",
+        "        self.variable = variable\n",
+        "        self._evidence = list(evidence)\n",
+        "        self.model = None\n",
+        "\n",
+        "    @property\n",
+        "    def variables(self):\n",
+        "        return [self.variable, *self._evidence]\n",
+        "\n",
+        "    @property\n",
+        "    def cardinality(self):\n",
+        "        # Not used for continuous model in this demo.\n",
+        "        return []\n",
+        "\n",
+        "    def get_evidence(self):\n",
+        "        return self._evidence\n",
+        "\n",
+        "    def fit(self, data):\n",
+        "        X = data[self._evidence]\n",
+        "        y = data[self.variable]\n",
+        "\n",
+        "        # Example skpro GAM regressor import.\n",
+        "        # If your installed skpro version exposes GAM at a different path,\n",
+        "        # adapt this import accordingly.\n",
+        "        from skpro.regression.gam import GAMRegressor\n",
+        "\n",
+        "        self.model = GAMRegressor()\n",
+        "        self.model.fit(X, y)\n",
+        "        return self\n",
+        "\n",
+        "cpd_c = SkproGAMCPD(variable=\"C\", evidence=[\"B\", \"D\"])\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# A and D are root nodes; for this hybrid estimation demo,\n",
+        "# we fit only CPD-like objects we provide in model.cpds.\n",
+        "model.add_cpds(cpd_b, cpd_c)\n",
+        "\n",
+        "# Optional check for B and C parent consistency\n",
+        "model.get_cpds(\"B\").get_evidence(), model.get_cpds(\"C\").get_evidence()\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# 3) Generate synthetic training data\n",
+        "rng = np.random.default_rng(42)\n",
+        "n = 500\n",
+        "\n",
+        "A = rng.integers(0, 2, size=n)\n",
+        "D = rng.normal(0.0, 1.0, size=n)\n",
+        "\n",
+        "# Sample B from the TabularCPD probabilities\n",
+        "p_B1_given_A = np.where(A == 0, 0.2, 0.7)\n",
+        "B = (rng.random(n) < p_B1_given_A).astype(int)\n",
+        "\n",
+        "# Continuous C depends nonlinearly on B and D\n",
+        "C = 2.0 * B + np.sin(D) + 0.3 * (D ** 2) + rng.normal(0.0, 0.2, size=n)\n",
+        "\n",
+        "data = pd.DataFrame({\"A\": A, \"B\": B, \"C\": C, \"D\": D})\n",
+        "data.head()\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# 4) Fit both CPDs/models with HybridEstimator\n",
+        "estimator = HybridEstimator()\n",
+        "estimator.fit(model=model, data=data)\n",
+        "\n",
+        "len(estimator.parameters_), [type(p).__name__ for p in estimator.parameters_]\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Inspect fitted outputs\n",
+        "fitted_b = estimator.parameters_[0]\n",
+        "fitted_c = estimator.parameters_[1]\n",
+        "\n",
+        "print(fitted_b)\n",
+        "print(\"\\nFitted skpro GAM model:\", fitted_c.model)\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.x"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}


### PR DESCRIPTION
### Motivation
- Provide an end-to-end example showing hybrid parameter learning using the refactored `BayesianNetwork` model that mixes discrete CPDs and external regressors. 
- Demonstrate how `HybridEstimator` can orchestrate fitting of both `TabularCPD` and a CPD-like wrapper around an `skpro` GAM regressor in a single workflow.

### Description
- Add `examples/Hybrid_Parameter_Learning_Refactored_BN.ipynb` which builds a network with edges `A -> B`, `B -> C`, `D -> C` and attaches CPD-like objects. 
- Use a `TabularCPD` for node `B` and a `SkproGAMCPD` CPD-like wrapper (implements `variable`, `get_evidence`, and `fit(data)`) for node `C` so it can be consumed by the estimator. 
- Generate synthetic data, call `model.add_cpds(...)`, and fit both parameter objects with `HybridEstimator().fit(model, data)`, then inspect fitted artifacts in the notebook.

### Testing
- Validated the notebook JSON by running `python -c "import json; json.load(open('examples/Hybrid_Parameter_Learning_Refactored_BN.ipynb'))"` which succeeded. 
- Added and committed the notebook to the repository with a descriptive commit message; no library code was modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f308fe6cc0832780bbada8ef3c6aa8)