### PR TITLE
Add NodeObject dataclass and get_node API to Refactored BayesianNetwork

### DIFF
--- a/pgmpy/models/Refactored_BayesianNetwork.py
+++ b/pgmpy/models/Refactored_BayesianNetwork.py
@@ -2,9 +2,21 @@ from __future__ import annotations
 
 from collections import defaultdict
 from collections.abc import Hashable, Iterable
+from dataclasses import dataclass, field
 from typing import Any
 
 from pgmpy.base import DAG
+
+
+@dataclass
+class NodeObject:
+    node: Hashable
+    parents: set[Hashable] = field(default_factory=set)
+    children: set[Hashable] = field(default_factory=set)
+    roles: set[str] = field(default_factory=set)
+    local_model: Any = None
+    estimator: Any = None
+    data: Any = None
 
 
 class BayesianNetwork(DAG):
@@ -33,6 +45,9 @@ class BayesianNetwork(DAG):
         )
         self.cpds = []
         self.cardinalities = defaultdict(int)
+        self.nodedict: dict[Hashable, NodeObject] = {}
+        for node in self.nodes():
+            self.nodedict[node] = NodeObject(node=node)
 
     def add_cpds(self, *cpds: Any) -> None:
         """Add CPDs to the model.
@@ -43,6 +58,17 @@ class BayesianNetwork(DAG):
         """
         for cpd in cpds:
             self.cpds.append(cpd)
+            if cpd.variable in self.nodedict:
+                self.nodedict[cpd.variable].local_model = cpd
+
+    def add_node(self, node_for_adding: Hashable, **attr: Any) -> None:
+        super().add_node(node_for_adding, **attr)
+        self.nodedict.setdefault(node_for_adding, NodeObject(node=node_for_adding))
+
+    def add_edge(self, u: Hashable, v: Hashable, **attr: Any) -> None:
+        super().add_edge(u, v, **attr)
+        self.nodedict.setdefault(u, NodeObject(node=u))
+        self.nodedict.setdefault(v, NodeObject(node=v))
 
     def get_cpds(self, node: Hashable | None = None) -> Any:
         """Return CPD(s) in the model or CPD associated with a node."""
@@ -56,6 +82,19 @@ class BayesianNetwork(DAG):
             if cpd.variable == node:
                 return cpd
         return None
+
+    def get_node(self, node: Hashable) -> NodeObject:
+        if node not in self.nodes():
+            raise ValueError("Node not present in the graph")
+
+        roles = {role for role in self.node[node].keys() if self.node[node][role]}
+        node_obj = self.nodedict.get(node, NodeObject(node=node))
+        node_obj.parents = set(self.predecessors(node))
+        node_obj.children = set(self.successors(node))
+        node_obj.roles = roles
+        node_obj.local_model = self.get_cpds(node=node)
+        self.nodedict[node] = node_obj
+        return node_obj
 
     def check_model(self) -> bool:
         """Validate that each node has a CPD and CPDs are structurally consistent."""

--- a/pgmpy/models/Refactored_BayesianNetwork.py
+++ b/pgmpy/models/Refactored_BayesianNetwork.py
@@ -87,7 +87,7 @@ class BayesianNetwork(DAG):
         if node not in self.nodes():
             raise ValueError("Node not present in the graph")
 
-        roles = {role for role in self.node[node].keys() if self.node[node][role]}
+        roles = {role for role in self[node].keys() if self[node][role]}
         node_obj = self.nodedict.get(node, NodeObject(node=node))
         node_obj.parents = set(self.predecessors(node))
         node_obj.children = set(self.successors(node))

--- a/pgmpy/tests/test_models/test_Refactored_BayesianNetwork.py
+++ b/pgmpy/tests/test_models/test_Refactored_BayesianNetwork.py
@@ -1,7 +1,7 @@
 import pytest
 
 from pgmpy.factors.discrete import TabularCPD
-from pgmpy.models.Refactored_BayesianNetwork import BayesianNetwork
+from pgmpy.models.Refactored_BayesianNetwork import BayesianNetwork, NodeObject
 
 
 class TestRefactoredBayesianNetwork:
@@ -42,3 +42,18 @@ class TestRefactoredBayesianNetwork:
 
         for method_name in ("fit", "predict", "simulate", "query"):
             assert not hasattr(model, method_name)
+
+    def test_get_node_returns_nodeobject_with_metadata(self):
+        model = BayesianNetwork([("B", "F")], roles={"instrument": ["B"]})
+        cpd_f = TabularCPD("F", 2, [[0.9, 0.2], [0.1, 0.8]], evidence=["B"], evidence_card=[2])
+        model.add_cpds(cpd_f)
+
+        node_obj = model.get_node("F")
+        assert isinstance(node_obj, NodeObject)
+        assert node_obj.node == "F"
+        assert node_obj.parents == {"B"}
+        assert node_obj.children == set()
+        assert node_obj.roles == set()
+        assert node_obj.local_model == cpd_f
+
+        assert model.get_node("B").roles == {"instrument"}


### PR DESCRIPTION
### Motivation
- Provide a first-class representation for per-node metadata so the refactored Bayesian network can store and expose node-level information (parents, children, roles, local model, estimator, data) in a structured way.
- Add an accessor to retrieve an up-to-date node metadata snapshot from the graph and associated CPDs.

### Description
- Added a `NodeObject` dataclass with fields `node`, `parents`, `children`, `roles`, `local_model`, `estimator`, and `data` in `pgmpy/models/Refactored_BayesianNetwork.py`.
- Added `self.nodedict: dict[Hashable, NodeObject]` initialization in `BayesianNetwork.__init__` and pre-populated entries for existing nodes.
- Updated `add_cpds` to attach CPDs to the corresponding node's `local_model`, and overrode `add_node` and `add_edge` to ensure newly added nodes are present in `self.nodedict`.
- Implemented `get_node(self, node)` which validates presence, updates parents/children/roles/local_model from the current graph/CPD state, stores the `NodeObject` in `nodedict`, and returns it.
- Added a focused test `test_get_node_returns_nodeobject_with_metadata` in `pgmpy/tests/test_models/test_Refactored_BayesianNetwork.py` that asserts the returned object is a `NodeObject` and verifies `parents`, `children`, `roles`, and `local_model`.

### Testing
- Ran `pytest -v pgmpy/tests/test_models/test_Refactored_BayesianNetwork.py` which failed during collection with `PackageNotFoundError: No package metadata was found for pgmpy` so tests could not be executed to completion.
- Re-ran with `PYTHONPATH=. pytest -v pgmpy/tests/test_models/test_Refactored_BayesianNetwork.py` which produced the same `PackageNotFoundError` during test collection.
- Attempted `pip install -e .[tests]` to install editable package and test deps, but dependency installation failed due to offline/proxy errors when fetching `setuptools>=61.0`, preventing a green test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f33d2541fc83279536eccc736d5481)