### PR TITLE
Add readable NodeObject.__str__ for Refactored_BayesianNetwork and test

### DIFF
--- a/pgmpy/models/Refactored_BayesianNetwork.py
+++ b/pgmpy/models/Refactored_BayesianNetwork.py
@@ -19,6 +19,21 @@ class NodeObject:
     data: Any = None
 
 
+    def __str__(self) -> str:
+        """Return a readable summary of node-level metadata."""
+        return (
+            "NodeObject("
+            f"node={self.node!r}, "
+            f"parents={sorted(self.parents, key=str)!r}, "
+            f"children={sorted(self.children, key=str)!r}, "
+            f"roles={sorted(self.roles)!r}, "
+            f"local_model={type(self.local_model).__name__ if self.local_model is not None else None}, "
+            f"estimator={type(self.estimator).__name__ if self.estimator is not None else None}, "
+            f"data={'set' if self.data is not None else None}"
+            ")"
+        )
+
+
 class BayesianNetwork(DAG):
     """Graph container for Bayesian network structure and CPD metadata.
 

--- a/pgmpy/tests/test_models/test_Refactored_BayesianNetwork.py
+++ b/pgmpy/tests/test_models/test_Refactored_BayesianNetwork.py
@@ -57,3 +57,18 @@ class TestRefactoredBayesianNetwork:
         assert node_obj.local_model == cpd_f
 
         assert model.get_node("B").roles == {"instrument"}
+
+
+    def test_get_node_string_representation_is_readable(self):
+        model = BayesianNetwork([("B", "F")], roles={"instrument": ["B"]})
+        cpd_f = TabularCPD("F", 2, [[0.9, 0.2], [0.1, 0.8]], evidence=["B"], evidence_card=[2])
+        model.add_cpds(cpd_f)
+
+        node_text = str(model.get_node("F"))
+
+        assert "NodeObject(" in node_text
+        assert "node='F'" in node_text
+        assert "parents=['B']" in node_text
+        assert "children=[]" in node_text
+        assert "roles=[]" in node_text
+        assert "local_model=TabularCPD" in node_text


### PR DESCRIPTION
### Motivation
- Improve developer ergonomics by making `NodeObject` instances returned from `BayesianNetwork.get_node(node)` print in a human-readable one-line summary. 
- Provide a stable, inspectable representation showing node id, parents, children, roles, and presence/type of attached metadata to ease debugging and REPL usage.

### Description
- Implemented `NodeObject.__str__` in `pgmpy/models/Refactored_BayesianNetwork.py` to return a compact summary including `node`, sorted `parents`, sorted `children`, sorted `roles`, `local_model` class name (or `None`), `estimator` class name (or `None`), and whether `data` is set. 
- Added `test_get_node_string_representation_is_readable` to `pgmpy/tests/test_models/test_Refactored_BayesianNetwork.py` which asserts that `str(model.get_node("F"))` contains the expected readable fields.

### Testing
- Ran `pytest -q pgmpy/tests/test_models/test_Refactored_BayesianNetwork.py`, but test collection failed at import time due to the package not being installed in the environment (import metadata not found), so tests could not be executed successfully. 
- Attempted `pip install -e .` to install the package for test execution, but the install failed due to network/proxy restrictions while resolving build dependency `setuptools>=61.0`, preventing a successful test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3401d5918832783d6e4bd121abec3)