### PR TITLE
Refactor node metadata storage in Refactored_BayesianNetwork to use networkx node attributes

### DIFF
--- a/pgmpy/models/Refactored_BayesianNetwork.py
+++ b/pgmpy/models/Refactored_BayesianNetwork.py
@@ -75,12 +75,6 @@ class BayesianNetwork(DAG):
             if cpd.variable in self.nodes:
                 self.nodes[cpd.variable]["local_model"] = cpd
 
-    def add_node(self, node_for_adding: Hashable, **attr: Any) -> None:
-        super().add_node(node_for_adding, **attr)
-
-    def add_edge(self, u: Hashable, v: Hashable, **attr: Any) -> None:
-        super().add_edge(u, v, **attr)
-
     def get_cpds(self, node: Hashable | None = None) -> Any:
         """Return CPD(s) in the model or CPD associated with a node."""
         if node is None:
@@ -99,7 +93,7 @@ class BayesianNetwork(DAG):
             raise ValueError("Node not present in the graph")
 
         node_attrs = self.nodes[node]
-        roles = {role for role, active in node_attrs.items() if isinstance(active, bool) and active}
+        roles = {role for role in self[node].keys() if self[node][role]}
 
         return NodeObject(
             node=node,

--- a/pgmpy/models/Refactored_BayesianNetwork.py
+++ b/pgmpy/models/Refactored_BayesianNetwork.py
@@ -10,6 +10,8 @@ from pgmpy.base import DAG
 
 @dataclass
 class NodeObject:
+    """Read-only view of node metadata returned by :meth:`BayesianNetwork.get_node`."""
+
     node: Hashable
     parents: set[Hashable] = field(default_factory=set)
     children: set[Hashable] = field(default_factory=set)
@@ -60,9 +62,6 @@ class BayesianNetwork(DAG):
         )
         self.cpds = []
         self.cardinalities = defaultdict(int)
-        self.nodedict: dict[Hashable, NodeObject] = {}
-        for node in self.nodes():
-            self.nodedict[node] = NodeObject(node=node)
 
     def add_cpds(self, *cpds: Any) -> None:
         """Add CPDs to the model.
@@ -73,17 +72,14 @@ class BayesianNetwork(DAG):
         """
         for cpd in cpds:
             self.cpds.append(cpd)
-            if cpd.variable in self.nodedict:
-                self.nodedict[cpd.variable].local_model = cpd
+            if cpd.variable in self.nodes:
+                self.nodes[cpd.variable]["local_model"] = cpd
 
     def add_node(self, node_for_adding: Hashable, **attr: Any) -> None:
         super().add_node(node_for_adding, **attr)
-        self.nodedict.setdefault(node_for_adding, NodeObject(node=node_for_adding))
 
     def add_edge(self, u: Hashable, v: Hashable, **attr: Any) -> None:
         super().add_edge(u, v, **attr)
-        self.nodedict.setdefault(u, NodeObject(node=u))
-        self.nodedict.setdefault(v, NodeObject(node=v))
 
     def get_cpds(self, node: Hashable | None = None) -> Any:
         """Return CPD(s) in the model or CPD associated with a node."""
@@ -102,14 +98,18 @@ class BayesianNetwork(DAG):
         if node not in self.nodes():
             raise ValueError("Node not present in the graph")
 
-        roles = {role for role in self[node].keys() if self[node][role]}
-        node_obj = self.nodedict.get(node, NodeObject(node=node))
-        node_obj.parents = set(self.predecessors(node))
-        node_obj.children = set(self.successors(node))
-        node_obj.roles = roles
-        node_obj.local_model = self.get_cpds(node=node)
-        self.nodedict[node] = node_obj
-        return node_obj
+        node_attrs = self.nodes[node]
+        roles = {role for role, active in node_attrs.items() if isinstance(active, bool) and active}
+
+        return NodeObject(
+            node=node,
+            parents=set(self.predecessors(node)),
+            children=set(self.successors(node)),
+            roles=roles,
+            local_model=node_attrs.get("local_model"),
+            estimator=node_attrs.get("estimator"),
+            data=node_attrs.get("data"),
+        )
 
     def check_model(self) -> bool:
         """Validate that each node has a CPD and CPDs are structurally consistent."""

--- a/pgmpy/tests/test_models/test_Refactored_BayesianNetwork.py
+++ b/pgmpy/tests/test_models/test_Refactored_BayesianNetwork.py
@@ -58,6 +58,14 @@ class TestRefactoredBayesianNetwork:
 
         assert model.get_node("B").roles == {"instrument"}
 
+    def test_local_model_is_stored_in_networkx_node_data(self):
+        model = BayesianNetwork()
+        local_model = object()
+        model.add_node("B", local_model=local_model)
+
+        assert model.nodes["B"]["local_model"] is local_model
+        assert model.get_node("B").local_model is local_model
+
 
     def test_get_node_string_representation_is_readable(self):
         model = BayesianNetwork([("B", "F")], roles={"instrument": ["B"]})


### PR DESCRIPTION
### Motivation
- Simplify per-node metadata management by removing a separate mutable `nodedict` cache and instead store node-level objects (e.g. `local_model`) on the underlying NetworkX node attributes.
- Provide a clear read-only view API for callers by making `NodeObject` a lightweight view assembled on access rather than a long-lived mutable container.

### Description
- Store per-node `local_model` (and other node attributes) in NetworkX node data via `self.nodes[node]["local_model"]` instead of maintaining `self.nodedict` in `BayesianNetwork` and update `add_cpds` to write into that attribute when the node exists.
- Change `get_node(node)` to return a `NodeObject` view composed from graph structure (`predecessors`/`successors`) and the node attributes (`local_model`, `estimator`, `data`, and boolean role flags) at access time.
- Remove creation/maintenance of `self.nodedict` and associated update logic so node state is sourced from networkx graph attributes only.
- Add a focused test `test_local_model_is_stored_in_networkx_node_data` verifying that `add_node(..., local_model=...)` persists to `model.nodes[...]["local_model"]` and is exposed by `get_node`.

### Testing
- Ran `pytest -q pgmpy/tests/test_models/test_Refactored_BayesianNetwork.py` which failed during test collection due to import metadata lookup error (`importlib.metadata.PackageNotFoundError: No package metadata was found for pgmpy`).
- Attempted `pip install -e .` to resolve import metadata but the build failed because environment pip could not fetch build dependencies (`setuptools>=61.0`) due to restricted network/proxy access, preventing full test execution.
- The added unit test is present and targets the behavior described, but end-to-end test execution in this environment was blocked by package/install constraints.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f348cf49988327b4e462c87f213ebe)