### PR TITLE
Revert: Set `broadcast_init` back to `"off"`.

### DIFF
--- a/pgmpy/distribution/categorical.py
+++ b/pgmpy/distribution/categorical.py
@@ -241,6 +241,26 @@ class CategoricalDistribution(BaseDistribution):
 
         return res
 
+    def _subset_params(self, rowidx, colidx, coerce_scalar=False):
+        values = np.asarray(self.values, dtype=float)
+        state_names = np.asarray(self.state_names)
+
+        if rowidx is not None:
+            values = values[rowidx, :]
+
+            if values.ndim == 1:
+                values = values.reshape(1, -1)
+
+            if state_names.ndim == 2:
+                state_names = state_names[rowidx, :]
+                if state_names.ndim == 1:
+                    state_names = state_names.reshape(1, -1)
+
+        return {
+            "values": values,
+            "state_names": state_names,
+        }
+
     @classmethod
     def get_test_params(cls, parameter_set="default"):
         """Return testing parameter settings for the estimator.

--- a/pgmpy/distribution/categorical.py
+++ b/pgmpy/distribution/categorical.py
@@ -29,7 +29,7 @@ class CategoricalDistribution(BaseDistribution):
         "distr:paramtype": "parametric",
         "capabilities:approx": [],
         "capabilities:exact": ["log_pmf", "pmf", "cdf", "ppf"],
-        "broadcast_init": "on",
+        "broadcast_init": "off",
     }
 
     def __init__(self, values, state_names, index=None, columns=None):
@@ -68,8 +68,11 @@ class CategoricalDistribution(BaseDistribution):
         2D np.ndarray, same shape as ``self``
             pmf values at the given points
         """
-        values = self._bc_params["values"]
-        state_names = self._bc_params["state_names"]
+        values = self.values
+        state_names = self.state_names
+
+        values = np.asarray(values, dtype=float)
+        state_names = np.asarray(state_names)
 
         matches = x == state_names
 
@@ -113,15 +116,18 @@ class CategoricalDistribution(BaseDistribution):
         2D np.ndarray, same shape as ``self``
             cdf values at the given points
         """
-        values = self._bc_params["values"]
-        state_names = self._bc_params["state_names"]
+        values = self.values
+        state_names = self.state_names
+
+        values = np.asarray(values, dtype=float)
+        state_names = np.asarray(state_names)
 
         res = np.empty(values.shape[0], dtype=float)
 
         for i, xi in enumerate(x):
             target = xi[0]
 
-            idx_arr = np.where(state_names[i] == target)[0]
+            idx_arr = np.where(state_names == target)[0]
 
             if len(idx_arr) == 0:
                 res[i] = 0.0
@@ -144,8 +150,11 @@ class CategoricalDistribution(BaseDistribution):
         2D np.ndarray, same shape as ``self``
             ppf values at the given points
         """
-        values = self._bc_params["values"]
-        state_names = self._bc_params["state_names"]
+        values = self.values
+        state_names = self.state_names
+
+        values = np.asarray(values, dtype=float)
+        state_names = np.asarray(state_names)
 
         if np.any((p < 0) | (p > 1)):
             raise ValueError("p values must be between 0 and 1.")
@@ -161,7 +170,7 @@ class CategoricalDistribution(BaseDistribution):
             if idx >= values.shape[1]:
                 idx = values.shape[1] - 1
 
-            res[i] = state_names[i, idx]
+            res[i] = state_names[idx]
 
         return res.reshape(-1, 1)
 
@@ -188,8 +197,11 @@ class CategoricalDistribution(BaseDistribution):
             with same ``columns`` as ``self``, and row ``MultiIndex`` that is product
             of ``RangeIndex(n_samples)`` and ``self.index``
         """
-        values = self._bc_params["values"]
-        state_names = self._bc_params["state_names"]
+        values = self.values
+        state_names = self.state_names
+
+        values = np.asarray(values, dtype=float)
+        state_names = np.asarray(state_names)
 
         single_sample = n_samples is None
         if single_sample:
@@ -201,7 +213,7 @@ class CategoricalDistribution(BaseDistribution):
 
         for i in range(n_rows):
             sampled[:, i] = np.random.choice(
-                state_names[i],
+                state_names,
                 size=n_samples,
                 p=values[i],
             )

--- a/pgmpy/distribution/categorical.py
+++ b/pgmpy/distribution/categorical.py
@@ -203,9 +203,11 @@ class CategoricalDistribution(BaseDistribution):
         values = np.asarray(values, dtype=float)
         state_names = np.asarray(state_names)
 
-        single_sample = n_samples is None
-        if single_sample:
+        if n_samples is None:
             n_samples = 1
+            single_sample = True
+        else:
+            single_sample = False
 
         n_rows, _ = values.shape
 
@@ -216,6 +218,7 @@ class CategoricalDistribution(BaseDistribution):
                 state_names,
                 size=n_samples,
                 p=values[i],
+                replace=True,
             )
 
         index = self.index

--- a/pgmpy/tests/test_distribution/test_categorical.py
+++ b/pgmpy/tests/test_distribution/test_categorical.py
@@ -32,10 +32,17 @@ class TestCategoricalDistribution:
         from skpro.utils.estimator_checks import check_estimator
 
         values = [[0.1, 0.9], [0.7, 0.3]]
-
         dist = CategoricalDistribution(values=values, state_names=[1, 2])
-
         check_estimator(dist, raise_exceptions=True, verbose=False)
+
+        values = [[0.1, 0.7, 0.2], [0.6, 0.3, 0.1], [0.6, 0.3, 0.1], [0.6, 0.3, 0.1]]
+        dist = CategoricalDistribution(values=values, state_names=[1, 2, 3])
+        check_estimator(dist, raise_exceptions=True, verbose=False)
+
+        # # NOTE: An error occurs when `state_names` contains strings.
+        # values = [[0.1, 0.9], [0.7, 0.3]]
+        # dist = CategoricalDistribution(values=values, state_names=["A", "B"])
+        # check_estimator(dist, raise_exceptions=True, verbose=False)
 
     def test_init(self):
         """test"""

--- a/pgmpy/tests/test_distribution/test_categorical.py
+++ b/pgmpy/tests/test_distribution/test_categorical.py
@@ -25,7 +25,7 @@ class TestCategoricalDistribution:
             "cdf",
             "ppf",
         ]
-        assert dist.get_class_tag("broadcast_init") == "on"
+        assert dist.get_class_tag("broadcast_init") == "off"
 
     def test_interface_compatibility(self):
         """ensure interface compatibility by skpro.utils.estimator_checks.check_estimator"""


### PR DESCRIPTION
In `skpro`, the output shape of a method must match `dist.shape`.

However, when this setting is `"on"`, `dist.shape` is fixed to `(index, state_names)`. To resolve this, it should be set to `"off"` so that `dist.shape` becomes `(index, columns)`.