### PR TITLE
ENH: Add LikelihoodWeighting approximate inference (refactored_inference/LW)

### DIFF
--- a/pgmpy/base/_base.py
+++ b/pgmpy/base/_base.py
@@ -162,6 +162,7 @@ class _CoreGraph(nx.MultiGraph, _GraphAlgorithms, _GraphRolesMixin, _GraphPlotti
         roles: dict[str, str | Iterable[Hashable]] | None = None,
     ):
         super().__init__()
+        self.cpds = {}
         if edge_list:
             edge_list = list(edge_list)  # materialize: _validate_edges below would exhaust a generator
             self._validate_edges(edge_list=edge_list)
@@ -179,6 +180,27 @@ class _CoreGraph(nx.MultiGraph, _GraphAlgorithms, _GraphRolesMixin, _GraphPlotti
 
         for role, vars in roles.items():
             self.with_role(role=role, variables=vars, inplace=True)
+
+    def add_cpd(self, node: Hashable, cpd: Any) -> None:
+        """Associate a fitted conditional distribution with a graph node.
+
+        Parameters
+        ----------
+        node : hashable
+            Node for which ``cpd`` defines a conditional distribution.
+        cpd : pgmpy.parameter.BaseParameter
+            Fitted parameter object used to sample the node given its parents.
+        """
+        if node not in self.nodes:
+            raise ValueError(f"Node {node!r} is not present in the graph.")
+        self.cpds[node] = cpd
+
+    def get_cpd(self, node: Hashable) -> Any:
+        """Return the conditional distribution associated with ``node``."""
+        try:
+            return self.cpds[node]
+        except KeyError as error:
+            raise ValueError(f"No CPD is associated with node {node!r}.") from error
 
     def add_edge(
         self,

--- a/pgmpy/parameter/adapter/SklearnAdapter.py
+++ b/pgmpy/parameter/adapter/SklearnAdapter.py
@@ -39,6 +39,7 @@ class SklearnAdapter(_DelegatedProbaRegressor, BaseParameter):
 
         estimator = self._get_delegate()
         self.columns_ = y.columns[0]
+        self.evidences_ = list(X.columns)
         estimator.fit(X=X, y=y, sample_weight=sample_weight)
 
         if is_regressor(estimator):

--- a/pgmpy/parameter/adapter/SkproAdapter.py
+++ b/pgmpy/parameter/adapter/SkproAdapter.py
@@ -22,6 +22,7 @@ class SkproAdapter(_DelegatedProbaRegressor, BaseParameter):
     def _fit(self, X, y, sample_weight=None):
 
         estimator = self._get_delegate()
+        self.evidences_ = list(X.columns)
         estimator.fit(X=X, y=y, C=sample_weight)
         return self
 

--- a/pgmpy/refactored_inference/LW.py
+++ b/pgmpy/refactored_inference/LW.py
@@ -1,10 +1,114 @@
+import networkx as nx
+import numpy as np
+import pandas as pd
+
 from ._base import BaseInference
 
 
 class LikelihoodWeighting(BaseInference):
-    _tags = {...}
+    """Likelihood-weighting inference for Bayesian networks with fitted CPDs.
+
+    The algorithm supports the parameter objects in :mod:`pgmpy.parameter`.
+    It returns weighted samples instead of a discrete factor, which permits a
+    single API for discrete and continuous variables.
+    """
+
+    _tags = {"individual": "BayesianNetwork"}
 
     def __init__(self):
         super().__init__()
 
-    def query(self, model, variables, evidence=None, do=None): ...
+    def query(self, model, variables, evidence=None, do=None, n_samples=10_000, seed=None):
+        """Draw weighted posterior samples for ``variables``.
+
+        Parameters
+        ----------
+        model : pgmpy.base._base._CoreGraph
+            A directed acyclic graph with one fitted CPD per node, added with
+            :meth:`~pgmpy.base._base._CoreGraph.add_cpd`.
+        variables : str or list[str]
+            Variables to retain in the returned samples.
+        evidence : dict, optional
+            Observed variable values. Their conditional probability (or
+            density) is incorporated into each sample's importance weight.
+        do : dict, optional
+            Interventions mapping variables to fixed values. Intervened nodes
+            are fixed without contributing a likelihood term.
+        n_samples : int, default=10000
+            Number of likelihood-weighted samples to generate.
+        seed : int, numpy.random.Generator, optional
+            Random state used for sampling.
+
+        Returns
+        -------
+        pandas.DataFrame
+            One row per generated sample, containing ``variables`` and a
+            normalized ``"weight"`` column.
+        """
+        if isinstance(variables, str):
+            variables = [variables]
+        else:
+            variables = list(variables)
+        evidence = {} if evidence is None else dict(evidence)
+        do = {} if do is None else dict(do)
+
+        nodes = set(model.nodes)
+        unknown = (set(variables) | set(evidence) | set(do)) - nodes
+        if unknown:
+            raise ValueError(f"Variables not found in the model: {unknown}")
+        if set(evidence) & set(do):
+            raise ValueError("A variable cannot be both evidence and an intervention.")
+        if not isinstance(n_samples, int) or n_samples < 1:
+            raise ValueError("n_samples must be a positive integer.")
+
+        graph = model.get_directed_graph()
+        if set(graph.edges) != {(u, v) for u, v, _ in model.get_edges(edge_types={"->"})}:
+            raise ValueError("Likelihood weighting requires a model containing only directed edges.")
+        if not nx.is_directed_acyclic_graph(graph):
+            raise ValueError("Likelihood weighting requires an acyclic model.")
+
+        order = list(nx.topological_sort(graph))
+        missing_cpds = [node for node in order if node not in model.cpds]
+        if missing_cpds:
+            raise ValueError(f"The model has no CPDs for nodes: {missing_cpds}")
+
+        rng = np.random.default_rng(seed)
+        samples = []
+        log_weights = np.empty(n_samples, dtype=float)
+        for sample_index in range(n_samples):
+            assignment = {}
+            log_weight = 0.0
+            for node in order:
+                cpd = model.get_cpd(node)
+                parents = list(cpd.evidences_) if getattr(cpd, "evidences_", None) is not None else []
+                features = pd.DataFrame([{parent: assignment[parent] for parent in parents}])
+                if not parents:
+                    features = pd.DataFrame({node: [0]})
+                distribution = cpd.predict_proba(features)
+                if hasattr(distribution, "rng_"):
+                    distribution.rng_ = rng
+
+                if node in do:
+                    assignment[node] = do[node]
+                elif node in evidence:
+                    assignment[node] = evidence[node]
+                    values = pd.DataFrame({node: [assignment[node]]})
+                    if cpd.get_tag("variable_type") == "discrete":
+                        probability = distribution.pmf(values)
+                    else:
+                        probability = distribution.pdf(values)
+                    with np.errstate(divide="ignore"):
+                        log_weight += np.log(float(np.asarray(probability).reshape(-1)[0]))
+                else:
+                    assignment[node] = distribution.sample().iloc[0, 0]
+
+            samples.append({variable: assignment[variable] for variable in variables})
+            log_weights[sample_index] = log_weight
+
+        max_log_weight = np.max(log_weights)
+        if not np.isfinite(max_log_weight):
+            raise ValueError("The evidence has zero probability under the model.")
+        weights = np.exp(log_weights - max_log_weight)
+        result = pd.DataFrame(samples)
+        result["weight"] = weights / weights.sum()
+        return result

--- a/pgmpy/tests/test_refactored_inference/test_LW.py
+++ b/pgmpy/tests/test_refactored_inference/test_LW.py
@@ -1,0 +1,32 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from pgmpy.base._base import _CoreGraph
+from pgmpy.parameter import TabularCPD
+from pgmpy.refactored_inference.LW import LikelihoodWeighting
+
+
+def _binary_chain():
+    model = _CoreGraph(edge_list=[("A", "B", "->")])
+    model.SUPPORTED_EDGE_TYPES = frozenset(["->", "<-"])
+
+    a = TabularCPD(categories={"A": [0, 1]}).fit(pd.DataFrame({"A": [0, 0, 1, 1]}))
+    b = TabularCPD(categories={"B": [0, 1]}).fit(pd.DataFrame({"A": [0, 0, 1, 1]}), pd.DataFrame({"B": [0, 0, 0, 1]}))
+    model.add_cpd("A", a)
+    model.add_cpd("B", b)
+    return model
+
+
+def test_query_returns_normalized_weighted_samples_for_evidence():
+    samples = LikelihoodWeighting().query(_binary_chain(), variables=["A"], evidence={"B": 1}, n_samples=2_000, seed=42)
+
+    assert list(samples.columns) == ["A", "weight"]
+    assert samples["weight"].sum() == pytest.approx(1.0)
+    assert np.average(samples["A"].astype(float), weights=samples["weight"]) == pytest.approx(1.0)
+
+
+def test_query_applies_interventions_without_likelihood_weighting_them():
+    samples = LikelihoodWeighting().query(_binary_chain(), variables=["B"], do={"A": 0}, n_samples=2_000, seed=42)
+
+    assert np.average(samples["B"].astype(float), weights=samples["weight"]) == pytest.approx(0.0, abs=0.05)


### PR DESCRIPTION
### Motivation
- Provide a likelihood-weighting approximate inference implementation for the refactored inference API that works with the new parameter/CPD classes (tabular, linear-Gaussian, sklearn/skpro adapters) and supports both evidence weighting and do-interventions.
- Allow attaching fitted parameter objects (CPDs) to graph nodes so inference/sampling algorithms can retrieve and use them directly.
- Preserve parent-feature metadata for adapter-based CPDs so sampling and likelihood evaluation can build the correct feature frames.

### Description
- Add `cpds` storage and helpers to the core graph API: `add_cpd(node, cpd)` and `get_cpd(node)` on `_CoreGraph` to attach and retrieve fitted CPD/parameter objects. (`pgmpy/base/_base.py`)
- Implement `LikelihoodWeighting.query(...)` in `pgmpy/refactored_inference/LW.py` that: draws samples in topological order, applies `do` interventions (no likelihood term), incorporates evidence likelihood into log-weights, normalizes importance weights, and returns a `pandas.DataFrame` with the queried variables and a normalized `weight` column; supports discrete and continuous CPD predict_proba APIs and propagates RNG to distributions when available.
- Ensure adapter parameter classes record parent (feature) order by setting `evidences_` during `fit` in `SklearnAdapter` and `SkproAdapter` so `LikelihoodWeighting` can construct feature DataFrames correctly. (`pgmpy/parameter/adapter/SklearnAdapter.py`, `pgmpy/parameter/adapter/SkproAdapter.py`)
- Add focused tests exercising evidence weighting and interventions, returned sample shape, and normalization semantics. (`pgmpy/tests/test_refactored_inference/test_LW.py`)
- Ensure style/lint: run `ruff` checks and formatting on modified files.

### Testing
- Ran `pytest -q pgmpy/tests/test_refactored_inference/test_LW.py` and observed the likelihood-weighting focused tests pass (2 passed).
- Ran adapter tests `pytest -q pgmpy/tests/test_parameter/test_adapter/test_SklearnAdapter.py pgmpy/tests/test_parameter/test_adapter/test_SkproAdapter.py` and observed they passed (11 passed, 4 skipped, 2 warnings reported by sklearn).
- Ran static checks and formatting with `ruff` and a Python compile check; `ruff` reported fixes and after formatting all checked files pass lint/format checks.
- Note: `pre-commit` was not available in the environment so `pre-commit run` could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c9fc956ac832795ca6938e66bc020)