### PR TITLE
ENH: Return empirical likelihood-weighting posteriors

### DIFF
--- a/pgmpy/refactored_inference/LW.py
+++ b/pgmpy/refactored_inference/LW.py
@@ -1,6 +1,7 @@
 import networkx as nx
 import numpy as np
 import pandas as pd
+from skpro.distributions import Empirical
 
 from ._base import BaseInference
 
@@ -41,9 +42,9 @@ class LikelihoodWeighting(BaseInference):
 
         Returns
         -------
-        pandas.DataFrame
-            One row per generated sample, containing ``variables`` and a
-            normalized ``"weight"`` column.
+        skpro.distributions.Empirical
+            Empirical distribution over ``variables`` whose samples are
+            weighted by their normalized importance weights.
         """
         if isinstance(variables, str):
             variables = [variables]
@@ -109,6 +110,7 @@ class LikelihoodWeighting(BaseInference):
         if not np.isfinite(max_log_weight):
             raise ValueError("The evidence has zero probability under the model.")
         weights = np.exp(log_weights - max_log_weight)
-        result = pd.DataFrame(samples)
-        result["weight"] = weights / weights.sum()
-        return result
+        sample_index = pd.MultiIndex.from_product([[0], range(n_samples)], names=["instance", "sample"])
+        result = pd.DataFrame(samples, index=sample_index)
+        normalized_weights = pd.Series(weights / weights.sum(), index=sample_index)
+        return Empirical(spl=result, weights=normalized_weights)

--- a/pgmpy/tests/test_refactored_inference/test_LW.py
+++ b/pgmpy/tests/test_refactored_inference/test_LW.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pandas as pd
 import pytest
+from skpro.distributions import Empirical
 
 from pgmpy.base._base import _CoreGraph
 from pgmpy.parameter import TabularCPD
@@ -18,15 +19,18 @@ def _binary_chain():
     return model
 
 
-def test_query_returns_normalized_weighted_samples_for_evidence():
-    samples = LikelihoodWeighting().query(_binary_chain(), variables=["A"], evidence={"B": 1}, n_samples=2_000, seed=42)
+def test_query_returns_empirical_distribution_for_evidence():
+    distribution = LikelihoodWeighting().query(
+        _binary_chain(), variables=["A"], evidence={"B": 1}, n_samples=2_000, seed=42
+    )
 
-    assert list(samples.columns) == ["A", "weight"]
-    assert samples["weight"].sum() == pytest.approx(1.0)
-    assert np.average(samples["A"].astype(float), weights=samples["weight"]) == pytest.approx(1.0)
+    assert isinstance(distribution, Empirical)
+    assert list(distribution.spl.columns) == ["A"]
+    assert distribution.weights.sum() == pytest.approx(1.0)
+    assert np.average(distribution.spl["A"].astype(float), weights=distribution.weights) == pytest.approx(1.0)
 
 
 def test_query_applies_interventions_without_likelihood_weighting_them():
-    samples = LikelihoodWeighting().query(_binary_chain(), variables=["B"], do={"A": 0}, n_samples=2_000, seed=42)
+    distribution = LikelihoodWeighting().query(_binary_chain(), variables=["B"], do={"A": 0}, n_samples=2_000, seed=42)
 
-    assert np.average(samples["B"].astype(float), weights=samples["weight"]) == pytest.approx(0.0, abs=0.05)
+    assert np.average(distribution.spl["B"].astype(float), weights=distribution.weights) == pytest.approx(0.0, abs=0.05)


### PR DESCRIPTION
### Motivation
- Make `LikelihoodWeighting.query()` return a `skpro.distributions.Empirical` object so downstream code and tests consume a standard empirical distribution with normalized importance weights.

### Description
- Import `Empirical` from `skpro.distributions` and update the query docstring to indicate the new return type (`Empirical`).
- Build the sample table with a two-level `(instance, sample)` `MultiIndex` and construct normalized weights as a `pd.Series` to match `Empirical(spl=..., weights=...)` expectations.
- Replace the previous `DataFrame` + `"weight"` column return with `return Empirical(spl=result, weights=normalized_weights)`.
- Update tests in `pgmpy/tests/test_refactored_inference/test_LW.py` to assert the `Empirical` return, inspect `distribution.spl` for sample columns, and use `distribution.weights` for weighted averages.

### Testing
- `python -m compileall -q pgmpy/refactored_inference/LW.py pgmpy/tests/test_refactored_inference/test_LW.py` succeeded.
- `ruff check pgmpy/refactored_inference/LW.py pgmpy/tests/test_refactored_inference/test_LW.py` succeeded and `ruff format --check` passed.
- Focused `pytest` could not be executed in this environment because the test run requires installed project metadata for `pgmpy` and the external `skpro` dependency, which were not available; `skpro` installation was blocked by the environment network/proxy.
- `pre-commit` hooks were not run because `pre-commit` is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5cacb977608327811f3a9091c5bee6)